### PR TITLE
 [Refactor/user-signup] S3 원자적 처리 리펙토링

### DIFF
--- a/apps/accounts/urls/urls.py
+++ b/apps/accounts/urls/urls.py
@@ -10,6 +10,7 @@ from apps.accounts.views.user_views import (
     PasswordResetRequestView,
     ProfileUpdateView,
     SignUpView,
+    UserAvatarUpdateView,
 )
 
 app_name = "accounts"
@@ -20,6 +21,7 @@ urlpatterns = [
     path("signup/", SignUpView.as_view(), name="signup"),
     path("me/", CurrentUserView.as_view(), name="current-user"),
     path("profile/", ProfileUpdateView.as_view(), name="profile-update"),
+    path("profile/avatar/", UserAvatarUpdateView.as_view(), name="avatar-update"),
     path(
         "password-reset/request/", PasswordResetRequestView.as_view(), name="password-reset-request"
     ),

--- a/apps/core/S3/uploader.py
+++ b/apps/core/S3/uploader.py
@@ -84,6 +84,26 @@ class S3Uploader:
         return f"https://{bucket}.s3.{region}.amazonaws.com/"
 
     @classmethod
+    def extract_key_from_url(cls, url: str) -> str | None:
+        """
+        S3 URL에서 키 추출
+
+        Args:
+            url: S3 파일 URL (예: https://bucket.s3.region.amazonaws.com/avatars/uuid.png)
+
+        Returns:
+            str | None: S3 객체 키 (예: avatars/uuid.png) 또는 None
+        """
+        if not url:
+            return None
+
+        base_url = cls.get_s3_base_url()
+        if url.startswith(base_url):
+            return url[len(base_url) :]
+
+        return None
+
+    @classmethod
     @handle_s3_errors("파일 삭제")
     def delete_file(cls, key: str) -> dict[str, Any]:
         """

--- a/apps/core/S3/views.py
+++ b/apps/core/S3/views.py
@@ -23,7 +23,7 @@ class S3DirectUploadView(APIView):
 
     @extend_schema(
         summary="이미지 직접 업로드",
-        description="파일을 받아서 백엔드에서 직접 S3로 업로드합니다.",
+        description="S3 파일 업로드",
         request={
             "multipart/form-data": {
                 "type": "object",


### PR DESCRIPTION
## 📝 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
1. **아바타 업데이트 엔드포인트 구현** - `PATCH /api/accounts/profile/avatar/`로 새 이미지 업로드, 저장, 기존 이미지 삭제를 원자적으로 처리
2. **S3 URL 파싱 유틸 추가** - `extract_key_from_url()` 함수로 저장된 avatar_url에서 S3 키 자동 추출
3.  **자동 정리 기능** - 아바타 업데이트 시 기존 이미지를 S3에서 자동 삭제하여 스토리지 낭비 방지
4.  **원스톱 처리** - 기존 3단계(업로드→저장→삭제)를 하나의 API 호출로 통합, UX 개선
5.  **안전한 업데이트** - 기존 이미지 삭제 실패해도 새 아바타는 정상 저장되도록 예외 처

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 (예: Closes #123) -->
#8 

## 📋 변경 타입
<!-- 해당하는 항목에 [x] 표시해주세요 -->

- [ ] 새로운 기능 (New Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation)
- [ ] 스타일 변경 (Style)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포 (Build/Deploy)
- [ ] 기타 (Other)

## ✅ 체크리스트
<!-- PR 제출 전에 확인해주세요 -->

- [x] 로컬에서 테스트 완료
- [x] 코드 포맷팅 적용 (`./scripts/format.sh`)
- [x] 테스트 통과 (`./scripts/test.sh`)
- [ ] 마이그레이션 파일 포함 (필요한 경우)
- [ ] 문서 업데이트 (필요한 경우)

## 📸 스크린샷 (선택사항)
<!-- UI 변경이 있다면 스크린샷을 추가해주세요 -->


## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

