### PR TITLE
[Refactor / user-signup] 폼 가입 검증/정규화 강화 및 IntegrityError 메시지 개선

### DIFF
--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -48,7 +48,8 @@ class SignUpForm(UserCreationForm):
 
     def clean_nickname(self):
         """닉네임 중복 체크"""
-        nickname = self.cleaned_data.get("nickname")
+        nickname = (self.cleaned_data.get("nickname") or "").strip()
+        self.cleaned_data["nickname"] = nickname
         user = User.objects.filter(nickname=nickname).first()
         result = AccountService.check_availability(user, "닉네임")
         if not result["available"]:

--- a/apps/accounts/tests/test_forms.py
+++ b/apps/accounts/tests/test_forms.py
@@ -72,3 +72,8 @@ class SignUpFormTestCase(TestCase):
         form = SignUpForm(data=self._valid_data(email="new@test.com", nickname="중복닉"))
         self.assertFalse(form.is_valid())
         self.assertIn("탈퇴 예약", form.errors["nickname"][0])
+
+    def test_nickname_stripped_before_validation(self):
+        form = SignUpForm(data=self._valid_data(nickname="  공백닉  "))
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["nickname"], "공백닉")

--- a/apps/core/exceptions.py
+++ b/apps/core/exceptions.py
@@ -30,8 +30,9 @@ def custom_exception_handler(exc, context):
     }
     """
     if isinstance(exc, IntegrityError):
+        message = _get_integrity_error_message(exc)
         return Response(
-            {"error": {"code": "validation_error", "message": "이미 사용 중인 값입니다."}},
+            {"error": {"code": "validation_error", "message": message}},
             status=status.HTTP_400_BAD_REQUEST,
         )
 
@@ -92,3 +93,16 @@ class ServiceException(APIException):
             self.detail["code"] = code
         if details:
             self.detail["details"] = details
+
+
+def _get_integrity_error_message(exc: IntegrityError) -> str:
+    """Unique 제약 위반 메시지 구체화"""
+    cause = getattr(exc, "__cause__", None)
+    constraint = getattr(getattr(cause, "diag", None), "constraint_name", "")
+    raw = f"{constraint} {exc}"
+
+    if "email" in raw:
+        return "이미 사용 중인 이메일입니다."
+    if "nickname" in raw:
+        return "이미 사용 중인 닉네임입니다."
+    return "이미 사용 중인 값입니다."


### PR DESCRIPTION
## 📝 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
  - SignUpForm이 create_user()를 타도록 수정해 이메일 정규화와 UserStats 생성 누락을 해결.
  - 폼 이메일/닉네임 중복 검증을 서비스 가용성 체크와 통일하고 닉네임 공백 정규화 추가.
  - custom_exception_handler에서 IntegrityError를 400으로 처리하고 이메일/닉네임별 메시지 분기.
  - 폼 가입 흐름 테스트 보강(닉네임 공백 정규화 포함) 및 테스트 통과 확인.
  - 전반적으로 폼/서비스/에러 처리 흐름을 일관된 검증 정책으로 맞춤.

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 (예: Closes #123) -->


## 📋 변경 타입
<!-- 해당하는 항목에 [x] 표시해주세요 -->

- [ ] 새로운 기능 (New Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation)
- [ ] 스타일 변경 (Style)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포 (Build/Deploy)
- [ ] 기타 (Other)

## ✅ 체크리스트
<!-- PR 제출 전에 확인해주세요 -->

- [x] 로컬에서 테스트 완료
- [x] 코드 포맷팅 적용 (`./scripts/format.sh`)
- [x] 테스트 통과 (`./scripts/test.sh`)
- [ ] 마이그레이션 파일 포함 (필요한 경우)
- [ ] 문서 업데이트 (필요한 경우)

## 📸 스크린샷 (선택사항)
<!-- UI 변경이 있다면 스크린샷을 추가해주세요 -->


## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

