### PR TITLE
 [Refactor/minsoo] 로비 밀도 재조정 및 운영·게임 성능 보완: 카드 높이 축소, 가로 폭 확장, 운영 메트릭 오류 수정

### DIFF
--- a/templates/chess/lobby.html
+++ b/templates/chess/lobby.html
@@ -361,7 +361,7 @@
 <style>
 /* Lobby Styles */
 .lobby-container {
-    max-width: 1360px;
+    max-width: 1460px;
     margin: 0 auto;
     overflow-x: hidden;
 }
@@ -423,7 +423,7 @@
 .hero-controls {
     display: grid;
     gap: var(--space-md);
-    grid-template-columns: minmax(0, 1.14fr) repeat(2, minmax(300px, 0.93fr));
+    grid-template-columns: minmax(0, 1.2fr) repeat(2, minmax(340px, 1fr));
     grid-template-areas: "match users chat";
     margin-bottom: var(--space-md);
     align-items: stretch;
@@ -478,7 +478,7 @@
 
 .hero-control-card--users,
 .hero-control-card--chat {
-    min-height: clamp(460px, 50vh, 560px);
+    min-height: clamp(340px, 40vh, 420px);
 }
 
 .hero-card-head {
@@ -865,11 +865,11 @@
 
 /* Room List */
 .room-list {
-    min-height: 220px;
+    min-height: 140px;
 }
 
 .room-list--embedded {
-    min-height: 180px;
+    min-height: 120px;
 }
 
 .lobby-room-skeleton {
@@ -1045,7 +1045,7 @@
 
 .lobby-chat-card .chat-container {
     flex: 1;
-    min-height: 340px;
+    min-height: 260px;
 }
 
 .lobby-chat-card .section-header,
@@ -1072,7 +1072,7 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    min-height: 320px;
+    min-height: 240px;
 }
 
 .chat-messages {
@@ -1083,8 +1083,8 @@
     background-color: var(--color-bg-secondary);
     border-radius: var(--radius-md);
     margin-bottom: var(--space-md);
-    min-height: 220px;
-    max-height: 360px;
+    min-height: 180px;
+    max-height: 280px;
     display: flex;
     flex-direction: column;
 }
@@ -1337,8 +1337,8 @@
 .users-list {
     flex: 1;
     overflow-y: auto;
-    min-height: 240px;
-    max-height: 360px;
+    min-height: 120px;
+    max-height: 240px;
 }
 
 .user-item-skeleton {
@@ -1364,12 +1364,12 @@
 
 @media (min-width: 769px) {
     .room-list {
-        min-height: 300px;
+        min-height: 180px;
     }
 
     .hero-control-card--users,
     .hero-control-card--chat {
-        min-height: 520px;
+        min-height: 380px;
     }
 
     .hero-control-card--users .section-header,
@@ -1389,17 +1389,17 @@
     }
 
     .chat-container {
-        min-height: 340px;
+        min-height: 260px;
     }
 
     .chat-messages {
-        min-height: 240px;
-        max-height: 380px;
+        min-height: 180px;
+        max-height: 280px;
     }
 
     .users-list {
-        min-height: 260px;
-        max-height: 380px;
+        min-height: 120px;
+        max-height: 240px;
     }
 
     .lobby-content {


### PR DESCRIPTION
## 📝 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
  - 로비 상단 3열 구조를 다시 다듬어 게임/방, 접속자, 로비 채팅이 더 균형 있게 보이도록 조정했습니다.
  - 로비 전체 컨테이너 최대폭을 1360px에서 1460px로 늘려 데스크톱에서 좌우가 더 여유 있게 보이도록 했습니다.
  - 상단 3열 그리드도 게임/방 카드가 조금 더 넓고, 접속자/로비 채팅 카드도 최소 폭이 더 큰 구조로 바꿨습니다.
  - 그 결과 로비 카드들이 전보다 좌우로 더 시원하게 보이도록 정리됐습니다.
  - 동시에 로비 카드들의 세로 길이는 한 단계 더 줄였습니다.
  - 접속자 카드와 로비 채팅 카드의 최소 높이를 크게 낮춰 하단 빈 공간이 덜 남도록 했습니다.
  - 대기 중인 방 영역도 최소 높이를 줄여 방이 없을 때 카드 아래가 과하게 비지 않게 바꿨습니다.
  - 채팅 컨테이너, 채팅 메시지 영역, 접속자 목록의 최소/최대 높이도 전반적으로 더 낮췄습니다.
  - 그래서 데스크톱 기준으로 왼쪽 방 목록 하단, 가운데 접속자 하단, 오른쪽 채팅 하단에 남던 공백이 눈에 띄게 줄어든 상태입니다.
  - 모바일에서는 방 목록이 기본 접힘 상태로 시작하도록 이미 수정했고, 이전 저장 상태가 남아 있던 문제도 저장 키를 v2로 바꿔 초기화했습니다.
  - 모바일 접속자 카드가 유저 수가 적을 때 아래로 길게 비어 보이던 문제도 별도로 수정했습니다.
  - 모바일에서는 접속자/로비 채팅 카드 최소 높이를 해제하고, 접속자 목록의 max-height 제한도 없애 내용만큼만 보이게 바꿨습니다.
  - 로비 전체를 더 가볍게 보이게 하기 위해 카드 그림자 강도도 한 단계 낮췄습니다.
  - 로비 내부 방 아이템은 배경 톤을 조금 더 밝게 하고 hover 그림자도 가볍게 조정했습니다.
  - 로비 채팅 말풍선은 패딩, 최대 너비, 그림자, 닉네임/시간 간격을 줄여 더 슬림하게 보이도록 다듬었습니다.
  - 접속자 상태 뱃지도 더 얇은 pill 형태로 정리해 로비에 있음, 대국 중, 관전 중, 퍼즐 같은 상태가 덜 두꺼워 보이게 바꿨습니다.
  - 접속자 카드 하단 안내 박스도 점선 박스 느낌에서 더 가벼운 카드형으로 바뀌었습니다.
  - 모바일 네비게이션 깨짐도 같이 수정했습니다.
  - 모바일에서 프로필 버튼 최소 폭이 너무 커서 햄버거 메뉴를 밀어내던 문제를 해결했습니다.
  - 모바일 프로필 버튼은 아바타만 보이도록 축소했고, 알림 버튼 폭도 줄여 우측 영역 길이를 정상화했습니다.
  - 모바일에서는 앱 다운로드 버튼도 숨겨 햄버거 메뉴가 다시 안정적으로 보이게 했습니다.
  - 운영 리포트의 게임 섹션 에러도 같이 수정했습니다.
  - 원인은 Game 모델에 없는 status 필드를 메트릭 코드가 조회하고 있었기 때문이었고, 실제 모델 구조에 맞게 result 기준 집계로 고쳤습니다.
  - playing 집계는 result=Game.Status.PLAYING 기준으로, finished_today는 result != playing + finished_at__date=today 기준으로 정리했습니다.
  - 이 수정으로 관리자 운영 리포트의 게임 카드에서 보이던 Cannot resolve keyword 'status' 에러가 사라지게 됩니다.
  - 게임 화면 반응 속도 개선도 함께 반영했습니다.
  - 보드 렌더링 함수 renderBoard()에 animatePieceChanges 옵션을 추가해 초기 진입, 리매치, 리플레이, 상태 반영 같은 일반 렌더에서는 기물 등장/제거 애니메이션을 생략하도록 바꿨습니다.
  - 반대로 실제 실시간 착수는 기존 animateIncomingMove() 흐름을 유지해 수가 들어오는 느낌은 그대로 살렸습니다.
  - 화면 회전(orientationchange)과 창 크기 변경(resize) 때는 더 이상 보드 전체를 다시 렌더하지 않고, 채팅 FAB 가시성만 갱신하도록 줄였습니다.
  - 이로 인해 게임 첫 진입, 리플레이 전환, 리사이즈/회전 시 불필요한 보드 재렌더 비용이 줄어들었습니다.
  - 친구 페이지와 시즌 페이지 카드도 로비 톤에 맞춰 배경을 조금 더 밝고 가볍게, hover 그림자도 약하게 조정했습니다.
  - 이번 작업은 로비 밀도 재조정, 모바일 네비 정상화, 운영 메트릭 오류 수정, 게임 반응 속도 최적화를 한 번에 묶은 UI/성능 정리 작업입니다.

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 (예: Closes #123) -->


## 📋 변경 타입
<!-- 해당하는 항목에 [x] 표시해주세요 -->

- [ ] 새로운 기능 (New Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation)
- [ ] 스타일 변경 (Style)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포 (Build/Deploy)
- [ ] 기타 (Other)

## ✅ 체크리스트
<!-- PR 제출 전에 확인해주세요 -->

- [ ] 로컬에서 테스트 완료
- [ ] 코드 포맷팅 적용 (`./scripts/format.sh`)
- [ ] 테스트 통과 (`./scripts/test.sh`)
- [ ] 마이그레이션 파일 포함 (필요한 경우)
- [ ] 문서 업데이트 (필요한 경우)

## 📸 스크린샷 (선택사항)
<!-- UI 변경이 있다면 스크린샷을 추가해주세요 -->


## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

