### PR TITLE
[Refactor/minsoo]  커뮤니티 관리 UX 정리 및 인터랙션 고도화: 길드 공지 이력화, 전역 채팅 확장, 로비·길드 UI 정돈

### DIFF
--- a/static/css/community.css
+++ b/static/css/community.css
@@ -146,6 +146,7 @@
     border-radius: var(--radius-md);
     background: color-mix(in srgb, var(--color-bg-secondary) 94%, white);
     cursor: pointer;
+    text-align: left;
     transition: transform 0.14s ease, border-color var(--transition-fast), box-shadow var(--transition-fast), background-color var(--transition-fast);
 }
 
@@ -400,9 +401,11 @@
 }
 
 .community-guild-row {
-    display: flex;
-    align-items: flex-start;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
     gap: 0.85rem;
+    width: 100%;
 }
 
 .community-guild-row--summary {
@@ -568,6 +571,20 @@
 .community-block {
     display: grid;
     gap: 0.5rem;
+    min-width: 0;
+}
+
+#guild-list .community-item-title,
+#guild-list .community-item-meta,
+#guild-list .community-item-copy {
+    overflow-wrap: anywhere;
+}
+
+#guild-list .community-item-copy {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 .community-card-slim {

--- a/static/js/pages/guilds.js
+++ b/static/js/pages/guilds.js
@@ -58,6 +58,18 @@
         return ACHIEVEMENT_LABELS[key] || '';
     }
 
+    function formatNoticeTimestamp(value) {
+        if (!value) return '';
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return '';
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
+        return `${year}/${month}/${day} ${hours}:${minutes}`;
+    }
+
     function setChatPanelExpanded(expanded) {
         if (!guildChatPanelEl || !guildChatToggleBtn) return;
         guildChatPanelEl.classList.toggle('hidden', !expanded);
@@ -177,9 +189,6 @@
                 </div>
             </div>
         `;
-        if (guildNoticeInput) {
-            guildNoticeInput.value = guild.notice || '';
-        }
         if (guildJoinBtn) {
             guildJoinBtn.disabled = Boolean(membership);
             guildJoinBtn.textContent = membership ? '가입 중' : '가입 신청';
@@ -317,7 +326,7 @@
             item.innerHTML = `
                 <div class="community-row">
                     <span class="community-item-title">${Utils.escapeHtml(notice.author?.nickname || '시스템 공지')}</span>
-                    <span class="community-item-meta">${Utils.formatDateTime ? Utils.formatDateTime(notice.created_at) : notice.created_at}</span>
+                    <span class="community-item-meta">${Utils.escapeHtml(formatNoticeTimestamp(notice.created_at))}</span>
                 </div>
                 <span class="community-item-copy community-item-copy--detail">${Utils.escapeHtml(notice.content || '')}</span>
             `;
@@ -440,8 +449,34 @@
     async function saveNotice(event) {
         event.preventDefault();
         if (!selectedGuildId) return;
-        await API.post(`/community/guilds/${selectedGuildId}/notice/`, { notice: guildNoticeInput.value.trim() });
+        const notice = guildNoticeInput.value.trim();
+        if (!notice) {
+            Toast.error('공지 내용을 입력하세요.');
+            return;
+        }
+        const data = await API.post(`/community/guilds/${selectedGuildId}/notice/`, { notice });
+        if (selectedGuild) {
+            selectedGuild.notice = data.notice || notice;
+            renderGuildSummary(selectedGuild);
+        }
+        renderNoticeHistory(data.results || []);
+        guildNoticeInput.value = '';
         Toast.success('길드 공지를 저장했습니다.');
+    }
+
+    async function updateAvatar(event) {
+        event.preventDefault();
+        if (!selectedGuildId) return;
+        const file = guildAvatarInput?.files?.[0];
+        if (!file) {
+            Toast.error('업로드할 이미지를 먼저 선택하세요.');
+            return;
+        }
+        const formData = new FormData();
+        formData.append('avatar', file);
+        await API.patch(`/community/guilds/${selectedGuildId}/avatar/`, formData, true);
+        guildAvatarInput.value = '';
+        Toast.success('길드 프로필 사진을 업데이트했습니다.');
         await loadGuildDetail(selectedGuildId);
     }
 
@@ -495,22 +530,6 @@
         if (!content) return;
         await API.post(`/community/guilds/${selectedGuildId}/chat/`, { content });
         input.value = '';
-        await loadGuildDetail(selectedGuildId);
-    }
-
-    async function updateAvatar(event) {
-        event.preventDefault();
-        if (!selectedGuildId) return;
-        const file = guildAvatarInput?.files?.[0];
-        if (!file) {
-            Toast.error('업로드할 이미지를 먼저 선택하세요.');
-            return;
-        }
-        const formData = new FormData();
-        formData.append('avatar', file);
-        await API.patch(`/community/guilds/${selectedGuildId}/avatar/`, formData, true);
-        guildAvatarInput.value = '';
-        Toast.success('길드 프로필 사진을 업데이트했습니다.');
         await loadGuildDetail(selectedGuildId);
     }
 

--- a/templates/chess/lobby.html
+++ b/templates/chess/lobby.html
@@ -407,8 +407,6 @@
     display: inline-flex;
     align-items: center;
     gap: 0.25em;
-    position: relative;
-    left: -56px;
 }
 
 .hero-logo {
@@ -436,8 +434,6 @@
     color: var(--color-text-secondary);
     font-size: 0.875rem;
     margin-bottom: var(--space-xl);
-    position: relative;
-    left: -56px;
 }
 
 .hero-guide-bar {
@@ -446,8 +442,6 @@
     flex-wrap: wrap;
     gap: 10px;
     margin-bottom: var(--space-md);
-    position: relative;
-    left: -40px;
 }
 
 .hero-controls {

--- a/templates/components/navbar.html
+++ b/templates/components/navbar.html
@@ -290,6 +290,13 @@
     flex: 0 0 auto;
 }
 
+.navbar-cluster-toggle {
+    font-size: 0.73rem;
+    font-weight: 400;
+    padding: 0.42rem 0.48rem;
+    line-height: 1;
+}
+
 .navbar-cluster.is-active .navbar-cluster-toggle {
     color: var(--color-accent-primary);
     background: color-mix(in srgb, var(--color-accent-primary) 10%, transparent);


### PR DESCRIPTION
## 📝 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
  - 길드와 파티 관리 흐름이 둘러보기와 내 관리로 분리되어, 찾는 화면과 운영하는 화면의 목적이 더 또렷해졌습니다.
  - 길드 둘러보기에서는 소개와 멤버 구성만 보이게 정리되어, 가입 전 화면이 덜 복잡하고 더 읽기 쉬워졌습니다.
  - 길드 관리 화면은 브랜딩 / 공지 / 멤버 관리 / 길드 채팅 / 가입 요청 탭으로 정리되어, 필요한 기능만 바로 찾을 수 있게 바뀌었습니다.
  - 길드 공지는 단일 입력이 아니라 이력형으로 바뀌어, 이전 공지를 계속 확인하면서 최신 공지를 관리할 수 있게 됐습니다.
  - 공지 저장 시 길드원에게 알림이 전송되도록 연결되어, 공지가 실제 운영 메시지 채널처럼 동작하게 됐습니다.
  - 공지 이력 시간 표시는 사람이 읽기 쉬운 YYYY/MM/DD HH:MM 형식으로 단순화되어, 긴 ISO 문자열 때문에 보기 불편하던 문제가 줄었습니다.
  - 공지 작성 후에는 입력창이 즉시 비워지고, 방금 저장한 공지가 우측 이력과 길드 요약에 바로 반영되어 새로고침 없이 결과를 확인할 수 있게 됐습니다.
  - 길드 운영 로그는 제거되어, 관리 화면이 불필요한 정보로 무거워 보이던 문제가 정리됐습니다.
  - 전역 채팅 패널은 로비 / 1:1 / 길드 / 파티 탭 구조로 확장되어, 여러 채널을 한 패널 안에서 빠르게 오갈 수 있게 됐습니다.
  - 길드/파티 채팅에도 1:1과 같은 뒤로가기가 추가되어, 목록 복귀 흐름이 더 자연스러워졌습니다.
  - 파티는 숫자 ID 입력 초대에서 벗어나 닉네임 검색과 현재 접속자 선택 기반으로 바뀌어, 초대 UX가 훨씬 직관적으로 정리됐습니다.
  - 길드/파티 생성 직후에는 바로 관리 화면으로 이어져, 만들고 나서 다시 찾아가야 하던 흐름이 사라졌습니다.
  - 로비 히어로는 제목·부제·안내 버튼 정렬이 다시 맞춰져, ChessOK 로고가 더 안정적으로 중앙에 보이도록 정리됐습니다.
  - 상단 네비는 커뮤니티 메뉴 크기와 간격을 다른 메뉴와 같은 톤으로 맞춰, 특정 메뉴만 튀어 보이던 문제를 줄였습니다.
  - 길드 목록 카드는 아바타와 텍스트 레이아웃을 다시 잡아, 제목과 메타가 미묘하게 잘리거나 눌려 보이던 UI가 더 안정적으로 보이게 바뀌었습니다.

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 (예: Closes #123) -->


## 📋 변경 타입
<!-- 해당하는 항목에 [x] 표시해주세요 -->

- [ ] 새로운 기능 (New Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation)
- [ ] 스타일 변경 (Style)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포 (Build/Deploy)
- [ ] 기타 (Other)

## ✅ 체크리스트
<!-- PR 제출 전에 확인해주세요 -->

- [ ] 로컬에서 테스트 완료
- [ ] 코드 포맷팅 적용 (`./scripts/format.sh`)
- [ ] 테스트 통과 (`./scripts/test.sh`)
- [ ] 마이그레이션 파일 포함 (필요한 경우)
- [ ] 문서 업데이트 (필요한 경우)

## 📸 스크린샷 (선택사항)
<!-- UI 변경이 있다면 스크린샷을 추가해주세요 -->


## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

