### PR TITLE
[Refactor/minsoo] 게임·로비·커뮤니티 UX/성능 고도화: 실시간 동기화 보강, 관리 흐름 분리, 전역 채팅 확장,모바일 레이아웃 정리

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -92,11 +92,21 @@ urlpatterns = [
     path("friends/", TemplateView.as_view(template_name="social/friends.html"), name="friends"),
     path("guilds/", TemplateView.as_view(template_name="community/guilds.html"), name="guilds"),
     path(
+        "guilds/create/",
+        TemplateView.as_view(template_name="community/guilds_create.html"),
+        name="guilds-create",
+    ),
+    path(
         "guilds/manage/",
         TemplateView.as_view(template_name="community/guilds_manage.html"),
         name="guilds-manage",
     ),
     path("parties/", TemplateView.as_view(template_name="community/parties.html"), name="parties"),
+    path(
+        "parties/create/",
+        TemplateView.as_view(template_name="community/parties_create.html"),
+        name="parties-create",
+    ),
     path(
         "parties/manage/",
         TemplateView.as_view(template_name="community/parties_manage.html"),

--- a/static/css/community.css
+++ b/static/css/community.css
@@ -1,8 +1,11 @@
 .community-page {
     max-width: 1560px;
+    width: min(100%, 1560px);
     margin: 0 auto;
     display: grid;
     gap: 1rem;
+    min-width: 0;
+    overflow-x: clip;
 }
 
 .community-hero {
@@ -37,14 +40,20 @@
 .community-grid {
     display: grid;
     gap: 1rem;
+    min-width: 0;
 }
 
 .community-grid--three {
-    grid-template-columns: minmax(300px, 0.94fr) minmax(350px, 1.04fr) minmax(400px, 1.18fr);
+    grid-template-columns: minmax(300px, 0.9fr) minmax(410px, 1.16fr) minmax(400px, 1.14fr);
 }
 
 .community-grid--manage {
     grid-template-columns: minmax(280px, 0.78fr) minmax(0, 1.72fr);
+    align-items: start;
+}
+
+.community-grid--browse {
+    grid-template-columns: minmax(280px, 0.84fr) minmax(0, 1.16fr);
     align-items: start;
 }
 
@@ -71,6 +80,8 @@
     align-content: start;
     content-visibility: auto;
     contain-intrinsic-size: 360px;
+    min-width: 0;
+    box-sizing: border-box;
 }
 
 .community-card--sidebar {
@@ -82,6 +93,10 @@
 .community-card--manage-detail .community-detail {
     display: grid;
     gap: 1rem;
+}
+
+.community-card--browse-main {
+    gap: 0.95rem;
 }
 
 .community-card--detail .community-detail {
@@ -117,6 +132,7 @@
 .community-list {
     display: grid;
     gap: 0.75rem;
+    min-width: 0;
 }
 
 .community-form-group {
@@ -360,6 +376,17 @@
     min-width: 140px;
 }
 
+.community-form .form-input,
+.community-inline-form .form-input,
+.community-form textarea.form-input,
+.community-form select.form-input,
+.community-form input.form-input {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+}
+
 .community-inline-form--stack {
     align-items: stretch;
 }
@@ -403,6 +430,7 @@
     grid-template-columns: auto 1fr;
     gap: 0.7rem;
     align-items: center;
+    min-width: 0;
 }
 
 .community-guild-row {
@@ -411,6 +439,7 @@
     align-items: center;
     gap: 0.85rem;
     width: 100%;
+    min-width: 0;
 }
 
 .community-guild-row--list {
@@ -458,6 +487,14 @@
 .community-file-field {
     display: grid;
     gap: 0.45rem;
+}
+
+.community-file-field .form-input[type='file'] {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .community-file-label {
@@ -619,6 +656,8 @@
 
 #guild-list .community-item {
     align-items: start;
+    overflow: visible;
+    padding: 0.95rem 1rem;
 }
 
 #guild-list .community-item-title {
@@ -627,11 +666,33 @@
 }
 
 #guild-list .community-guild-avatar.is-compact {
-    width: 54px;
-    height: 54px;
-    flex-basis: 54px;
+    width: 56px;
+    height: 56px;
+    flex-basis: 56px;
     border-radius: 18px;
     font-size: 1.08rem;
+}
+
+#guild-list .community-guild-row--list {
+    grid-template-columns: 56px minmax(0, 1fr);
+    align-items: start;
+    gap: 0.9rem;
+}
+
+#guild-list .community-block--tight {
+    min-width: 0;
+    align-content: start;
+    justify-items: start;
+}
+
+#guild-list .community-row--start,
+#guild-list .community-guild-list-meta {
+    width: 100%;
+    justify-content: flex-start;
+}
+
+#guild-list .community-item-copy--clamp2 {
+    width: 100%;
 }
 
 #guild-summary .community-item-copy {
@@ -732,6 +793,7 @@
 
 @media (max-width: 1120px) {
     .community-grid--manage,
+    .community-grid--browse,
     .community-grid--three,
     .community-grid--two,
     .community-grid--board,
@@ -765,6 +827,10 @@
 }
 
 @media (max-width: 768px) {
+    .community-page {
+        gap: 0.85rem;
+    }
+
     .community-hero--split {
         flex-direction: column;
         align-items: start;
@@ -797,6 +863,23 @@
     .community-card {
         padding: 0.95rem;
         gap: 0.82rem;
+    }
+
+    .community-guild-row,
+    #guild-list .community-guild-row--list,
+    .community-member-main {
+        grid-template-columns: 52px minmax(0, 1fr);
+        gap: 0.72rem;
+        align-items: start;
+    }
+
+    .community-guild-avatar,
+    .community-guild-avatar.is-compact {
+        width: 52px;
+        height: 52px;
+        flex-basis: 52px;
+        border-radius: 16px;
+        font-size: 1.02rem;
     }
 
     .community-manager-grid,
@@ -840,6 +923,10 @@
 }
 
 @media (max-width: 640px) {
+    .community-page {
+        gap: 0.75rem;
+    }
+
     .community-hero-actions {
         width: 100%;
     }
@@ -851,6 +938,20 @@
 
     .community-card {
         padding: 0.85rem;
+    }
+
+    .community-card-head p,
+    .community-note,
+    .community-item-meta,
+    .community-item-copy {
+        line-height: 1.52;
+    }
+
+    .community-guild-list-meta,
+    .community-row-meta,
+    .community-member-meta,
+    .community-member-title {
+        gap: 0.3rem;
     }
 
     .community-card-head h2,

--- a/static/css/customize.css
+++ b/static/css/customize.css
@@ -179,6 +179,33 @@
     gap: 12px;
 }
 
+.customize-shop-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 16px;
+}
+
+.customize-shop-tab {
+    border: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-bg-secondary) 90%, white);
+    color: var(--color-text-secondary);
+    border-radius: 999px;
+    padding: 8px 14px;
+    font-size: 0.82rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: border-color 0.16s ease, color 0.16s ease, background-color 0.16s ease, transform 0.16s ease;
+}
+
+.customize-shop-tab:hover,
+.customize-shop-tab.is-active {
+    border-color: color-mix(in srgb, var(--color-accent-primary) 38%, white);
+    color: var(--color-accent-primary);
+    background: color-mix(in srgb, var(--color-accent-primary) 8%, white);
+    transform: translateY(-1px);
+}
+
 .customize-option-card {
     margin: 0;
     padding: 16px;
@@ -186,6 +213,11 @@
     border: 1px solid var(--color-border);
     background: color-mix(in srgb, var(--color-bg-secondary) 84%, white);
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+    display: none;
+}
+
+.customize-option-card.is-active {
+    display: grid;
 }
 
 .customize-option-head {
@@ -230,6 +262,12 @@
 
 .customize-choice-grid--compact {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.customize-preview-card {
+    position: sticky;
+    top: calc(var(--navbar-height, 72px) + 16px);
+    align-self: start;
 }
 
 .customize-choice-card {
@@ -965,6 +1003,11 @@
         grid-template-columns: 1fr;
     }
 
+    .customize-preview-card {
+        position: static;
+        order: -1;
+    }
+
     .customize-preview-showroom {
         grid-template-columns: 1fr;
     }
@@ -995,6 +1038,22 @@
 
     .customize-card {
         padding: 18px;
+    }
+
+    .customize-shop-tabs {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        padding-bottom: 2px;
+        scrollbar-width: none;
+    }
+
+    .customize-shop-tabs::-webkit-scrollbar {
+        display: none;
+    }
+
+    .customize-shop-tab {
+        flex: 0 0 auto;
+        white-space: nowrap;
     }
 
     .customize-points-card {

--- a/static/js/pages/customize.js
+++ b/static/js/pages/customize.js
@@ -39,6 +39,8 @@
     const summaryFrameState = document.getElementById('customize-summary-frame-state');
     const purchaseBtn = document.getElementById('customize-purchase');
     const saveBtn = document.getElementById('customize-save');
+    const shopTabButtons = Array.from(document.querySelectorAll('[data-customize-tab]'));
+    const shopPanes = Array.from(document.querySelectorAll('[data-customize-pane]'));
     const boardOptions = document.getElementById('customize-board-options');
     const pieceOptions = document.getElementById('customize-piece-options');
     const colorOptions = document.getElementById('customize-color-options');
@@ -263,6 +265,7 @@
     }
 
     function bindEvents() {
+        setupShopTabs();
         boardSkinSelect?.addEventListener('change', renderPreview);
         pieceSkinSelect?.addEventListener('change', renderPreview);
         nicknameColorSelect?.addEventListener('change', renderPreview);
@@ -271,6 +274,22 @@
         profileCardFrameSelect?.addEventListener('change', renderPreview);
         purchaseBtn?.addEventListener('click', handlePurchase);
         saveBtn?.addEventListener('click', handleApply);
+    }
+
+    function setupShopTabs() {
+        if (!shopTabButtons.length || !shopPanes.length) return;
+        const activate = (key) => {
+            shopTabButtons.forEach((button) => {
+                button.classList.toggle('is-active', button.dataset.customizeTab === key);
+            });
+            shopPanes.forEach((pane) => {
+                pane.classList.toggle('is-active', pane.dataset.customizePane === key);
+            });
+        };
+        shopTabButtons.forEach((button) => {
+            button.addEventListener('click', () => activate(button.dataset.customizeTab));
+        });
+        activate(shopTabButtons[0].dataset.customizeTab);
     }
 
     async function loadSkinCatalog() {

--- a/static/js/pages/game.js
+++ b/static/js/pages/game.js
@@ -150,12 +150,15 @@
     let wsReconnectAttempts = 0;
     const WS_MAX_RECONNECT_ATTEMPTS = 10;
     const WS_BASE_RECONNECT_DELAY = 1000;
+    let wsReconnectTimer = null;
+    let resumeSyncInFlight = false;
+    let lastResumeSyncAt = 0;
     let notificationEventBound = false;
     let notificationEventHandler = null;
     let selectedBoardSkinClass = 'skin-board-classic';
     let selectedPieceSkinClass = 'skin-piece-classic';
     let lastMoveListSignature = null;
-    let activeSidePanelSectionId = 'game-moves-section';
+    let activeSidePanelSectionId = window.innerWidth <= 900 ? 'game-actions' : 'game-moves-section';
     const pieceSvgMarkupCache = new Map();
 
     function showStatus(message, type = 'info', duration = 1800) {
@@ -256,6 +259,49 @@
         if (replayDock.parentElement === sidePanel) return;
         const anchor = spectatorSection || chatSection || null;
         sidePanel.insertBefore(replayDock, anchor);
+    }
+
+    function clearReconnectTimer() {
+        if (!wsReconnectTimer) return;
+        clearTimeout(wsReconnectTimer);
+        wsReconnectTimer = null;
+    }
+
+    function teardownSocket({ silent = false } = {}) {
+        if (!socket) return;
+        if (silent) {
+            socket.onopen = null;
+            socket.onmessage = null;
+            socket.onclose = null;
+            socket.onerror = null;
+        }
+        try {
+            socket.close();
+        } catch {
+            // noop
+        }
+        socket = null;
+    }
+
+    function syncPerspectiveFromGame() {
+        myColor = null;
+        opponentUserId = null;
+
+        if (currentUser) {
+            if (game?.white_player?.id === currentUser.id) {
+                myColor = 'white';
+            } else if (game?.black_player?.id === currentUser.id) {
+                myColor = 'black';
+            }
+        }
+
+        if (currentUser && myColor === 'white') {
+            opponentUserId = game?.black_player?.id || null;
+        } else if (currentUser && myColor === 'black') {
+            opponentUserId = game?.white_player?.id || null;
+        }
+
+        isSpectator = !myColor;
     }
 
     /**
@@ -383,21 +429,7 @@
                 }
             }
 
-            // 내 색상 결정
-            if (currentUser) {
-                if (game.white_player?.id === currentUser.id) {
-                    myColor = 'white';
-                } else if (game.black_player?.id === currentUser.id) {
-                    myColor = 'black';
-                }
-            }
-            if (currentUser && myColor === 'white') {
-                opponentUserId = game.black_player?.id || null;
-            } else if (currentUser && myColor === 'black') {
-                opponentUserId = game.white_player?.id || null;
-            }
-
-            isSpectator = !myColor;
+            syncPerspectiveFromGame();
 
             if (!myColor || replayOnly) {
                 gameActions?.classList.add('hidden');
@@ -558,21 +590,7 @@
         }
         game = fetched;
 
-        if (currentUser) {
-            if (game.white_player?.id === currentUser.id) {
-                myColor = 'white';
-            } else if (game.black_player?.id === currentUser.id) {
-                myColor = 'black';
-            } else {
-                myColor = null;
-            }
-        }
-        opponentUserId = null;
-        if (currentUser && myColor === 'white') {
-            opponentUserId = game.black_player?.id || null;
-        } else if (currentUser && myColor === 'black') {
-            opponentUserId = game.white_player?.id || null;
-        }
+        syncPerspectiveFromGame();
 
         renderPlayerBars();
         renderBoard({ animatePieceChanges: false });
@@ -682,13 +700,13 @@
         if (!sidePanel) return;
         const sections = Array.from(sidePanel.querySelectorAll('.panel-section'));
         if (!sections.length) return;
-        const storageKey = 'game_side_panel_sections_v2';
+        const storageKey = 'game_side_panel_sections_v3';
         const defaultStates = {
             'game-actions': false,
-            'game-moves-section': false,
+            'game-moves-section': window.innerWidth <= 900,
             'captured-section': true,
             'spectator-section': true,
-            'game-chat-section': window.innerWidth <= 1360,
+            'game-chat-section': window.innerWidth <= 900,
         };
         const isNarrow = () => window.innerWidth <= 1360;
 
@@ -716,6 +734,10 @@
                 setCollapsed(section, collapsed);
                 header.dataset.accordionMode = narrow ? 'single' : 'multi';
             });
+            if (states[activeSidePanelSectionId]) {
+                activeSidePanelSectionId = narrow ? 'game-actions' : 'game-moves-section';
+            }
+            setActiveSidePanelTab(activeSidePanelSectionId);
             syncGameChatFabVisibility();
         };
 
@@ -1681,20 +1703,35 @@
     /**
      * WebSocket 연결
      */
-    function connectWebSocket() {
+    function connectWebSocket({ force = false, suppressStatus = false } = {}) {
+        if (replayOnly) return;
+        clearReconnectTimer();
+        if (socket && !force) {
+            if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+                return;
+            }
+        }
+        if (socket && force) {
+            teardownSocket({ silent: true });
+        }
         socket = socketClient?.connect({
             roomId,
             onOpen: () => {
-                addChatNotice('연결되었습니다.');
+                if (!suppressStatus) {
+                    addChatNotice('연결되었습니다.');
+                }
                 wsReconnectAttempts = 0;
                 startHeartbeat();
                 refreshSpectatorList();
-                showStatus('게임 실시간 연결 완료', 'success', 1200);
+                if (!suppressStatus) {
+                    showStatus('게임 실시간 연결 완료', 'success', 1200);
+                }
             },
             onMessage: (data) => {
                 handleSocketMessage(data);
             },
             onClose: () => {
+                socket = null;
                 addChatNotice('연결이 끊어졌습니다.');
                 stopHeartbeat();
                 if (wsReconnectAttempts >= WS_MAX_RECONNECT_ATTEMPTS) {
@@ -1706,12 +1743,64 @@
                 const delay = Math.min(WS_BASE_RECONNECT_DELAY * Math.pow(2, wsReconnectAttempts - 1), 30000);
                 addChatNotice(`${Math.round(delay / 1000)}초 후 재연결 시도 (${wsReconnectAttempts}/${WS_MAX_RECONNECT_ATTEMPTS})...`);
                 showStatus(`${Math.round(delay / 1000)}초 후 게임 연결 재시도`, 'pending', 1500);
-                setTimeout(connectWebSocket, delay);
+                wsReconnectTimer = setTimeout(() => {
+                    wsReconnectTimer = null;
+                    connectWebSocket({ suppressStatus: true });
+                }, delay);
             },
             onError: () => {
                 addChatNotice('연결 오류');
             },
         }) || null;
+    }
+
+    async function syncLiveGameStateOnResume({ forceReconnect = false } = {}) {
+        if (replayOnly || !game?.id) return;
+        const now = Date.now();
+        if (resumeSyncInFlight || now - lastResumeSyncAt < 900) return;
+        lastResumeSyncAt = now;
+        resumeSyncInFlight = true;
+
+        try {
+            if (forceReconnect || !socket || socket.readyState === WebSocket.CLOSED || socket.readyState === WebSocket.CLOSING) {
+                connectWebSocket({ force: forceReconnect, suppressStatus: true });
+            } else if (socket.readyState === WebSocket.OPEN) {
+                socketClient?.sendJson?.(socket, { action: 'heartbeat' });
+            }
+
+            const previousResult = game.result;
+            const latestGame = await API.get(`/chess/games/${game.id}/`);
+            if (game?.room_type && !latestGame.room_type) {
+                latestGame.room_type = game.room_type;
+            }
+            game = latestGame;
+
+            syncPerspectiveFromGame();
+
+            renderPlayerBars();
+            renderBoard({ animatePieceChanges: false });
+            renderMoveList();
+            updateTurn();
+
+            const syncTasks = [loadCapturedPieces(), refreshSpectatorList()];
+            if (game.move_count > 0) {
+                syncTasks.push(loadLastMove());
+            } else {
+                lastMove = null;
+            }
+            await Promise.allSettled(syncTasks);
+            renderCapturedPieces();
+            renderBoard({ animatePieceChanges: false });
+            updateTurn();
+
+            if (game.result !== 'playing' && previousResult === 'playing') {
+                showGameEndModal(game.result);
+            }
+        } catch (error) {
+            console.error('Failed to sync game after resume:', error);
+        } finally {
+            resumeSyncInFlight = false;
+        }
     }
 
     /**
@@ -2915,18 +3004,40 @@
 
     // 페이지 떠날 때 정리
     window.addEventListener('beforeunload', () => {
+        clearReconnectTimer();
         stopHeartbeat();
         if (timerInterval) clearInterval(timerInterval);
         if (isAiRoom) {
             sendAiResign();
         }
-        if (socket) socket.close();
+        teardownSocket({ silent: true });
     });
 
-    window.addEventListener('pagehide', () => {
+    window.addEventListener('pagehide', (event) => {
+        clearReconnectTimer();
+        stopHeartbeat();
+        if (event.persisted) {
+            teardownSocket({ silent: true });
+        }
         if (isAiRoom) {
             sendAiResign();
         }
+    });
+
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+            stopHeartbeat();
+            return;
+        }
+        syncLiveGameStateOnResume({ forceReconnect: true });
+    });
+
+    window.addEventListener('pageshow', () => {
+        syncLiveGameStateOnResume({ forceReconnect: true });
+    });
+
+    window.addEventListener('focus', () => {
+        syncLiveGameStateOnResume();
     });
 
     // 화면 회전 시 보드 크기 재계산

--- a/static/js/pages/guilds.js
+++ b/static/js/pages/guilds.js
@@ -15,6 +15,9 @@
     const detailEmptyEl = document.getElementById('guild-detail-empty');
     const detailPanelEl = document.getElementById('guild-detail-panel');
     const guildSummaryEl = document.getElementById('guild-summary');
+    const currentGuildEmptyEl = document.getElementById('guild-current-empty');
+    const currentGuildPanelEl = document.getElementById('guild-current-panel');
+    const currentGuildSummaryEl = document.getElementById('guild-current-summary');
     const guildMembersEl = document.getElementById('guild-members');
     const guildChatLogEl = document.getElementById('guild-chat-log');
     const guildChatPanelEl = document.getElementById('guild-chat-panel');
@@ -232,6 +235,34 @@
         setChatPanelExpanded(window.innerWidth > 768);
     }
 
+    function renderCurrentGuildCard(guild) {
+        if (!currentGuildSummaryEl || !currentGuildEmptyEl || !currentGuildPanelEl) return;
+        if (!guild?.id) {
+            currentGuildPanelEl.classList.add('hidden');
+            currentGuildEmptyEl.classList.remove('hidden');
+            return;
+        }
+        const membership = (guild.members || []).find((member) => member.user.id === me?.id) || null;
+        currentGuildEmptyEl.classList.add('hidden');
+        currentGuildPanelEl.classList.remove('hidden');
+        currentGuildSummaryEl.innerHTML = `
+            <div class="community-item community-item--detail">
+                <div class="community-guild-row community-guild-row--summary">
+                    ${renderGuildAvatar(guild.avatar_url, guild.name)}
+                    <div class="community-block">
+                        <span class="community-item-title">${Utils.escapeHtml(guild.name)}</span>
+                        <span class="community-item-meta">팀 레이팅 ${guild.team_rating} · 멤버 ${guild.member_count}명</span>
+                        <span class="community-item-copy">${Utils.escapeHtml(guild.notice || guild.description || '아직 공지가 없습니다.')}</span>
+                    </div>
+                </div>
+                <div class="community-row-meta">
+                    <span class="community-badge">${Utils.escapeHtml(guild.join_policy === 'open' ? '자유 가입' : '승인제')}</span>
+                    ${membership ? `<span class="community-badge is-ready">내 역할 · ${Utils.escapeHtml(membership.role)}</span>` : ''}
+                </div>
+            </div>
+        `;
+    }
+
     function renderMembers(guild) {
         if (!guildMembersEl) return;
         const members = guild.members || [];
@@ -422,6 +453,12 @@
         }
     }
 
+    async function loadCurrentGuildCard() {
+        if (!currentGuildSummaryEl) return;
+        const guild = await API.get('/community/guilds/me/current/').catch(() => ({ guild_id: null }));
+        renderCurrentGuildCard(guild);
+    }
+
     async function loadGuildDetail(guildId) {
         selectedGuildId = guildId;
         const [guild, guildList] = await Promise.all([
@@ -485,7 +522,7 @@
             window.location.href = '/guilds/';
             return;
         }
-        await loadGuilds();
+        await Promise.all([loadCurrentGuildCard(), loadGuilds()]);
     }
 
     async function createGuildBattle() {
@@ -497,6 +534,10 @@
     async function saveNotice(event) {
         event.preventDefault();
         if (!selectedGuildId) return;
+        if (!guildNoticeInput) {
+            Toast.error('공지 입력창을 찾지 못했습니다.');
+            return;
+        }
         const notice = guildNoticeInput.value.trim();
         if (!notice) {
             Toast.error('공지 내용을 입력하세요.');
@@ -515,6 +556,10 @@
     async function updateAvatar(event) {
         event.preventDefault();
         if (!selectedGuildId) return;
+        if (!guildAvatarInput) {
+            Toast.error('길드 이미지 입력창을 찾지 못했습니다.');
+            return;
+        }
         const file = guildAvatarInput?.files?.[0];
         if (!file) {
             Toast.error('업로드할 이미지를 먼저 선택하세요.');
@@ -586,8 +631,10 @@
         setupManageTabs();
         if (pageMode === 'manage') {
             await loadCurrentGuildDetail();
+        } else if (pageMode === 'create') {
+            // Creation page only needs the form bindings below.
         } else {
-            await loadGuilds();
+            await Promise.all([loadCurrentGuildCard(), loadGuilds()]);
         }
         document.getElementById('guild-create-form')?.addEventListener('submit', (event) => submitCreate(event).catch((error) => Toast.error(error.data?.message || error.message)));
         guildJoinBtn?.addEventListener('click', () => joinGuild().catch((error) => Toast.error(error.data?.message || error.message)));

--- a/static/js/pages/parties.js
+++ b/static/js/pages/parties.js
@@ -20,6 +20,9 @@
     const detailEmptyEl = document.getElementById('party-detail-empty');
     const detailPanelEl = document.getElementById('party-detail-panel');
     const partySummaryEl = document.getElementById('party-summary');
+    const currentPartyEmptyEl = document.getElementById('party-current-empty');
+    const currentPartyPanelEl = document.getElementById('party-current-panel');
+    const currentPartySummaryEl = document.getElementById('party-current-summary');
     const partyMembersEl = document.getElementById('party-members');
     const partyChatLogEl = document.getElementById('party-chat-log');
     const partyInviteListEl = document.getElementById('party-invite-list');
@@ -363,6 +366,27 @@
         setChatPanelExpanded(window.innerWidth > 768);
     }
 
+    function renderCurrentPartyCard(summary) {
+        if (!currentPartySummaryEl || !currentPartyEmptyEl || !currentPartyPanelEl) return;
+        if (!summary?.party_id) {
+            currentPartyPanelEl.classList.add('hidden');
+            currentPartyEmptyEl.classList.remove('hidden');
+            return;
+        }
+        currentPartyEmptyEl.classList.add('hidden');
+        currentPartyPanelEl.classList.remove('hidden');
+        currentPartySummaryEl.innerHTML = `
+            <div class="community-item community-item--detail">
+                <span class="community-item-title">${Utils.escapeHtml(summary.title || '내 파티')}</span>
+                <span class="community-item-meta">상태 ${Utils.escapeHtml(summary.status || 'open')} · 멤버 ${summary.member_count || 0}명</span>
+                <div class="community-row-meta">
+                    ${summary.is_leader ? '<span class="community-badge is-ready">파티장</span>' : '<span class="community-badge">참가 중</span>'}
+                    ${summary.can_invite ? '<span class="community-badge is-info">초대 가능</span>' : ''}
+                </div>
+            </div>
+        `;
+    }
+
     function renderChat(items) {
         const nextSignature = items.map((message) => [message.id, message.created_at || '', message.content || ''].join(':')).join('|');
         if (nextSignature === lastPartyChatSignature) return;
@@ -420,7 +444,7 @@
                     if (pageMode === 'manage') {
                         await loadCurrentPartyDetail();
                     } else {
-                        await loadParties();
+                        await Promise.all([loadCurrentPartyCard(), loadParties()]);
                     }
                 } catch (error) {
                     Toast.error(error.data?.message || error.message);
@@ -464,6 +488,12 @@
             return;
         }
         await loadPartyDetail(summary.party_id);
+    }
+
+    async function loadCurrentPartyCard() {
+        if (!currentPartySummaryEl) return;
+        const summary = await API.get('/community/parties/me/active/').catch(() => ({ party_id: null }));
+        renderCurrentPartyCard(summary);
     }
 
     async function loadPartyDetail(partyId) {
@@ -524,7 +554,7 @@
             window.location.href = '/parties/';
             return;
         }
-        await Promise.all([loadParties(), loadPendingInvites()]);
+        await Promise.all([loadCurrentPartyCard(), loadParties(), loadPendingInvites()]);
     }
 
     async function closeParty() {
@@ -542,7 +572,7 @@
             window.location.href = '/parties/';
             return;
         }
-        await Promise.all([loadParties(), loadPendingInvites()]);
+        await Promise.all([loadCurrentPartyCard(), loadParties(), loadPendingInvites()]);
     }
 
     async function inviteUser(event) {
@@ -637,8 +667,10 @@
         await loadPendingInvites();
         if (pageMode === 'manage') {
             await loadCurrentPartyDetail();
+        } else if (pageMode === 'create') {
+            // Creation page only needs form bindings below.
         } else {
-            await loadParties();
+            await Promise.all([loadCurrentPartyCard(), loadParties()]);
         }
         document.getElementById('party-create-form')?.addEventListener('submit', (event) => createParty(event).catch((error) => Toast.error(error.data?.message || error.message)));
         readyBtn?.addEventListener('click', () => toggleReady().catch((error) => Toast.error(error.data?.message || error.message)));

--- a/templates/accounts/customize.html
+++ b/templates/accounts/customize.html
@@ -74,8 +74,17 @@
                 </article>
             </div>
 
+            <div class="customize-shop-tabs" id="customize-shop-tabs" aria-label="커스터마이징 카테고리">
+                <button class="customize-shop-tab is-active" type="button" data-customize-tab="board">보드</button>
+                <button class="customize-shop-tab" type="button" data-customize-tab="piece">기물</button>
+                <button class="customize-shop-tab" type="button" data-customize-tab="color">닉네임 색상</button>
+                <button class="customize-shop-tab" type="button" data-customize-tab="border">프로필 테두리</button>
+                <button class="customize-shop-tab" type="button" data-customize-tab="title">시즌 칭호</button>
+                <button class="customize-shop-tab" type="button" data-customize-tab="frame">카드 프레임</button>
+            </div>
+
             <div class="customize-option-grid">
-                <div class="form-group customize-option-card">
+                <div class="form-group customize-option-card is-active" data-customize-pane="board">
                     <div class="customize-option-head">
                         <div>
                             <label class="form-label" for="customize-board-skin">보드 스킨</label>
@@ -86,7 +95,7 @@
                     <select class="form-input customize-native-select" id="customize-board-skin"></select>
                     <div class="customize-choice-grid" id="customize-board-options" aria-label="보드 스킨 선택"></div>
                 </div>
-                <div class="form-group customize-option-card">
+                <div class="form-group customize-option-card" data-customize-pane="piece">
                     <div class="customize-option-head">
                         <div>
                             <label class="form-label" for="customize-piece-skin">기물 스킨</label>
@@ -97,7 +106,7 @@
                     <select class="form-input customize-native-select" id="customize-piece-skin"></select>
                     <div class="customize-choice-grid" id="customize-piece-options" aria-label="기물 스킨 선택"></div>
                 </div>
-                <div class="form-group customize-option-card">
+                <div class="form-group customize-option-card" data-customize-pane="color">
                     <div class="customize-option-head">
                         <div>
                             <label class="form-label" for="customize-nickname-color">닉네임 색상</label>
@@ -108,7 +117,7 @@
                     <select class="form-input customize-native-select" id="customize-nickname-color"></select>
                     <div class="customize-choice-grid customize-choice-grid--compact" id="customize-color-options" aria-label="닉네임 색상 선택"></div>
                 </div>
-                <div class="form-group customize-option-card">
+                <div class="form-group customize-option-card" data-customize-pane="border">
                     <div class="customize-option-head">
                         <div>
                             <label class="form-label" for="customize-profile-border">프로필 테두리</label>
@@ -119,7 +128,7 @@
                     <select class="form-input customize-native-select" id="customize-profile-border"></select>
                     <div class="customize-choice-grid customize-choice-grid--compact" id="customize-border-options" aria-label="프로필 테두리 선택"></div>
                 </div>
-                <div class="form-group customize-option-card">
+                <div class="form-group customize-option-card" data-customize-pane="title">
                     <div class="customize-option-head">
                         <div>
                             <label class="form-label" for="customize-season-title">시즌 칭호</label>
@@ -130,7 +139,7 @@
                     <select class="form-input customize-native-select" id="customize-season-title"></select>
                     <div class="customize-choice-grid customize-choice-grid--compact" id="customize-title-options" aria-label="시즌 칭호 선택"></div>
                 </div>
-                <div class="form-group customize-option-card">
+                <div class="form-group customize-option-card" data-customize-pane="frame">
                     <div class="customize-option-head">
                         <div>
                             <label class="form-label" for="customize-profile-card-frame">프로필 카드 프레임</label>

--- a/templates/chess/game.html
+++ b/templates/chess/game.html
@@ -334,14 +334,15 @@
 /* Game Container */
 .game-container {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(600px, 660px);
+    grid-template-columns: minmax(700px, 760px) minmax(720px, 1fr);
     gap: var(--space-lg);
-    max-width: 1640px;
+    max-width: 1760px;
     width: 100%;
     margin: 0 auto;
     padding: var(--space-sm) var(--space-md);
     overflow-x: hidden;
     position: relative;
+    align-items: start;
 }
 
 .game-container::before {
@@ -386,6 +387,8 @@
     flex-direction: column;
     gap: var(--space-md);
     min-width: 0;
+    width: min(100%, 760px);
+    justify-self: center;
 }
 
 /* Player Bar */
@@ -425,21 +428,28 @@
     display: flex;
     align-items: center;
     gap: var(--space-sm);
+    flex: 1;
+    min-width: 0;
 }
 
 .player-bar-details {
     display: flex;
     flex-direction: column;
     min-width: 0;
+    gap: 2px;
 }
 
 .player-bar-name {
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    font-size: 0.75rem;
+    font-size: 0.82rem;
     font-weight: 500;
-    max-width: 190px;
+    max-width: 210px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .player-bar .tier-badge {
@@ -455,7 +465,7 @@
 }
 
 .player-bar-rating {
-    font-size: 0.75rem;
+    font-size: 0.72rem;
     color: var(--color-text-muted);
 }
 
@@ -464,7 +474,7 @@
     align-items: center;
     gap: 4px;
     width: fit-content;
-    max-width: 100%;
+    max-width: 178px;
     margin-top: 4px;
     padding: 3px 8px;
     border-radius: 999px;
@@ -544,7 +554,7 @@
     grid-template-columns: repeat(8, 1fr);
     grid-template-rows: repeat(8, 1fr);
     width: 100%;
-    max-width: 680px;
+    max-width: 720px;
     aspect-ratio: 1;
     border: 2px solid var(--color-border);
     border-radius: var(--radius-sm);
@@ -1611,8 +1621,8 @@ html[data-theme="dark"] .piece.white {
 }
 
 .side-panel-nav {
-    display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    display: flex;
+    align-items: stretch;
     gap: 8px;
     padding: 0.35rem;
     border: 1px solid var(--color-border);
@@ -1620,9 +1630,16 @@ html[data-theme="dark"] .piece.white {
     background:
         linear-gradient(180deg, color-mix(in srgb, var(--color-bg-card) 96%, white), color-mix(in srgb, var(--color-bg-secondary) 94%, white));
     box-shadow: 0 8px 16px rgba(74, 46, 24, 0.05);
+    overflow-x: auto;
+    scrollbar-width: none;
+}
+
+.side-panel-nav::-webkit-scrollbar {
+    display: none;
 }
 
 .side-panel-tab {
+    flex: 0 0 auto;
     border: 1px solid transparent;
     background: transparent;
     border-radius: 999px;
@@ -1630,6 +1647,7 @@ html[data-theme="dark"] .piece.white {
     color: var(--color-text-secondary);
     font-size: 0.73rem;
     font-weight: 700;
+    min-width: 88px;
     cursor: pointer;
     transition: background-color var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast), transform 0.14s ease;
 }
@@ -1657,7 +1675,7 @@ html[data-theme="dark"] .piece.white {
 
 .panel-top-grid {
     display: grid;
-    grid-template-columns: minmax(212px, 228px) minmax(388px, 1fr);
+    grid-template-columns: minmax(320px, 360px) minmax(440px, 1fr);
     gap: clamp(0.75rem, 1.2vw, var(--space-md));
     align-items: start;
 }
@@ -1748,27 +1766,32 @@ html[data-theme="dark"] .piece.white {
 .panel-copy {
     margin: 0;
     color: var(--color-text-muted);
-    font-size: 0.68rem;
-    line-height: 1.35;
+    font-size: 0.74rem;
+    line-height: 1.5;
 }
 
 .game-actions-panel .panel-header {
     border-bottom: 0;
     padding-bottom: var(--space-sm);
-    text-align: center;
+    text-align: left;
+    align-items: flex-start;
+}
+
+.game-actions-panel {
+    min-width: 0;
 }
 
 .game-actions-panel .action-grid {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: var(--space-sm);
     padding: 0 var(--space-md) var(--space-md);
 }
 
 .game-actions-panel .action-grid .btn {
-    min-width: 100px;
-    flex: 0 1 calc(50% - var(--space-sm) / 2);
+    min-width: 0;
+    width: 100%;
+    justify-content: center;
 }
 
 .panel-title {
@@ -1937,6 +1960,7 @@ html[data-theme="dark"] .piece.white {
 .panel-top-grid .game-chat {
     min-height: 320px;
     height: auto;
+    min-width: 0;
 }
 
 .panel-top-grid .game-chat .chat-messages {
@@ -1954,6 +1978,17 @@ html[data-theme="dark"] .piece.white {
 
     .side-panel-nav {
         grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 1500px) {
+    .game-container {
+        grid-template-columns: minmax(640px, 720px) minmax(580px, 1fr);
+        max-width: 1480px;
+    }
+
+    .panel-top-grid {
+        grid-template-columns: minmax(300px, 336px) minmax(360px, 1fr);
     }
 }
 
@@ -2677,7 +2712,7 @@ body.competitive-room #rematch-modal {
 }
 
 /* Responsive */
-@media (max-width: 1200px) {
+@media (max-width: 1320px) {
     .game-container {
         grid-template-columns: 1fr;
     }
@@ -2735,18 +2770,19 @@ body.competitive-room #rematch-modal {
 
     .player-bar {
         padding: var(--space-xs) var(--space-sm);
-        flex-direction: column;
-        gap: var(--space-xs);
-        align-items: stretch;
+        flex-direction: row;
+        gap: 8px;
+        align-items: center;
     }
 
     .player-bar-info {
         gap: var(--space-xs);
+        min-width: 0;
     }
 
     .player-bar-name {
-        font-size: 0.7rem;
-        max-width: 80px;
+        font-size: 0.72rem;
+        max-width: 118px;
     }
 
     .player-bar-rating {
@@ -2757,6 +2793,7 @@ body.competitive-room #rematch-modal {
         font-size: 0.58rem;
         padding: 2px 6px;
         margin-top: 3px;
+        max-width: 132px;
     }
 
     .player-bar-timer {
@@ -2796,7 +2833,12 @@ body.competitive-room #rematch-modal {
     }
 
     .panel-title {
-        font-size: 0.6rem;
+        font-size: 0.64rem;
+    }
+
+    .panel-copy {
+        font-size: 0.68rem;
+        line-height: 1.42;
     }
 
     .game-actions-panel .action-grid {
@@ -2829,7 +2871,7 @@ body.competitive-room #rematch-modal {
     }
 
     .player-bar-name {
-        max-width: 60px;
+        max-width: 92px;
         font-size: 0.65rem;
     }
 
@@ -2840,7 +2882,7 @@ body.competitive-room #rematch-modal {
     }
 
     .player-bar-achievement {
-        max-width: 94px;
+        max-width: 104px;
     }
 
     .chess-board-wrapper {

--- a/templates/community/guilds.html
+++ b/templates/community/guilds.html
@@ -10,44 +10,33 @@
             <p>길드를 만들고, 가입을 신청하고, 마음에 드는 길드를 둘러볼 수 있습니다.</p>
         </div>
         <div class="community-hero-actions">
+            <a class="btn btn-primary btn-sm" href="/guilds/create/">길드 생성</a>
             <a class="btn btn-secondary btn-sm" href="/guilds/manage/">내 길드 관리</a>
         </div>
     </section>
-    <div class="community-grid community-grid--three">
-        <section class="community-card">
+    <div class="community-grid community-grid--browse">
+        <section class="community-card community-card--sidebar">
             <div class="community-card-head">
-                <h2>길드 생성</h2>
-                <p>자유 가입 또는 승인제로 길드를 열 수 있습니다.</p>
+                <h2>내 길드</h2>
+                <p>현재 가입 중인 길드와 공지, 내 역할을 빠르게 확인합니다.</p>
             </div>
-            <form id="guild-create-form" class="community-form" enctype="multipart/form-data">
-                <label class="community-file-field">
-                    <span class="community-file-label">길드 프로필 사진</span>
-                    <input class="form-input" name="avatar" type="file" accept="image/*">
-                </label>
-                <input class="form-input" name="name" placeholder="길드명" maxlength="40" required>
-                <textarea class="form-input" name="description" placeholder="길드 설명" rows="4"></textarea>
-                <select class="form-input" name="join_policy">
-                    <option value="approval">승인제</option>
-                    <option value="open">자유 가입</option>
-                </select>
-                <input class="form-input" name="min_rating" type="number" min="0" max="4000" value="1200" placeholder="최소 레이팅">
-                <input class="form-input" name="active_hours" placeholder="활동 시간대 예: 평일 저녁">
-                <input class="form-input" name="contact_channel" placeholder="연락 수단 예: 오픈채팅">
-                <button class="btn btn-primary" type="submit">길드 생성</button>
-            </form>
+            <div id="guild-current-empty" class="community-empty">아직 가입한 길드가 없습니다. 길드 생성 또는 가입 신청으로 시작할 수 있습니다.</div>
+            <div id="guild-current-panel" class="community-detail hidden">
+                <div class="community-stack" id="guild-current-summary"></div>
+                <div class="community-actions community-actions--wrap">
+                    <a class="btn btn-primary btn-sm" href="/guilds/create/">길드 생성</a>
+                    <a class="btn btn-secondary btn-sm" href="/guilds/manage/">길드 관리</a>
+                </div>
+            </div>
         </section>
-        <section class="community-card community-card--list">
+
+        <section class="community-card community-card--browse-main">
             <div class="community-card-head">
                 <h2>길드 목록</h2>
-                <p>현재 모집 중인 길드를 확인합니다.</p>
+                <p id="guild-detail-subtitle">길드를 선택하면 소개와 멤버 구성을 바로 확인할 수 있습니다.</p>
             </div>
-            <div class="community-list" id="guild-list"></div>
-        </section>
-        <section class="community-card community-card--detail">
-            <div class="community-card-head">
-                <h2>길드 상세</h2>
-                <p id="guild-detail-subtitle">길드를 선택하면 소개와 멤버 구성을 확인할 수 있습니다.</p>
-            </div>
+            <div class="community-sublist" id="guild-list"></div>
+            <div class="community-divider"></div>
             <div id="guild-detail-empty" class="community-empty">아직 선택한 길드가 없습니다.</div>
             <div id="guild-detail-panel" class="community-detail hidden">
                 <div class="community-stack" id="guild-summary"></div>

--- a/templates/community/guilds_create.html
+++ b/templates/community/guilds_create.html
@@ -1,0 +1,54 @@
+{% extends 'base.html' %}
+
+{% block title %}길드 생성 - ChessOK{% endblock %}
+
+{% block content %}
+<div class="community-page" id="guild-page" data-view="create">
+    <section class="community-hero community-hero--split">
+        <div>
+            <h1>길드 생성</h1>
+            <p>자유 가입 또는 승인제로 새 길드를 열고, 브랜딩과 소개를 바로 구성할 수 있습니다.</p>
+        </div>
+        <div class="community-hero-actions">
+            <a class="btn btn-secondary btn-sm" href="/guilds/">길드 둘러보기</a>
+            <a class="btn btn-secondary btn-sm" href="/guilds/manage/">내 길드 관리</a>
+        </div>
+    </section>
+
+    <div class="community-grid community-grid--write">
+        <section class="community-card">
+            <div class="community-card-head">
+                <h2>새 길드 만들기</h2>
+                <p>프로필 사진, 소개, 가입 방식과 활동 시간대를 정하면 길드원이 더 빠르게 들어올 수 있습니다.</p>
+            </div>
+            <form id="guild-create-form" class="community-form" enctype="multipart/form-data">
+                <label class="community-file-field">
+                    <span class="community-file-label">길드 프로필 사진</span>
+                    <input class="form-input" name="avatar" type="file" accept="image/*">
+                </label>
+                <input class="form-input" name="name" placeholder="길드명" maxlength="40" required>
+                <textarea class="form-input" name="description" placeholder="길드 설명" rows="4"></textarea>
+                <select class="form-input" name="join_policy">
+                    <option value="approval">승인제</option>
+                    <option value="open">자유 가입</option>
+                </select>
+                <input class="form-input" name="min_rating" type="number" min="0" max="4000" value="1200" placeholder="최소 레이팅">
+                <input class="form-input" name="active_hours" placeholder="활동 시간대 예: 평일 저녁">
+                <input class="form-input" name="contact_channel" placeholder="연락 수단 예: 오픈채팅">
+                <div class="community-actions community-actions--wrap">
+                    <button class="btn btn-primary" type="submit">길드 생성</button>
+                    <a class="btn btn-secondary" href="/guilds/">둘러보기로 돌아가기</a>
+                </div>
+            </form>
+        </section>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="/static/css/community.css">
+{% endblock %}
+
+{% block extra_js %}
+<script src="/static/js/pages/guilds.js"></script>
+{% endblock %}

--- a/templates/community/parties.html
+++ b/templates/community/parties.html
@@ -10,40 +10,40 @@
             <p>3인 라인업을 만들고 3:3 연승제 단체전을 준비합니다.</p>
         </div>
         <div class="community-hero-actions">
+            <a class="btn btn-primary btn-sm" href="/parties/create/">파티 생성</a>
             <a class="btn btn-secondary btn-sm" href="/parties/manage/">내 파티 관리</a>
         </div>
     </section>
-    <div class="community-grid community-grid--three">
-        <section class="community-card">
+    <div class="community-grid community-grid--browse">
+        <section class="community-card community-card--sidebar">
             <div class="community-card-head">
-                <h2>파티 생성</h2>
-                <p>파티장 권한으로 초대, 슬롯 배정, 라인업 고정을 관리합니다.</p>
+                <h2>내 파티</h2>
+                <p>현재 참가 중인 파티와 받은 초대를 한곳에서 빠르게 확인합니다.</p>
             </div>
-            <div class="community-note" id="party-guest-note">게스트는 초대 수락 후 참가만 가능합니다.</div>
-            <form id="party-create-form" class="community-form">
-                <input class="form-input" name="title" placeholder="파티 이름" maxlength="60" required>
-                <textarea class="form-input" name="description" placeholder="파티 설명" rows="4"></textarea>
-                <button class="btn btn-primary" type="submit">파티 생성</button>
-            </form>
+            <div id="party-current-empty" class="community-empty">아직 참가 중인 파티가 없습니다. 파티를 만들거나 초대를 수락해 시작할 수 있습니다.</div>
+            <div id="party-current-panel" class="community-detail hidden">
+                <div class="community-stack" id="party-current-summary"></div>
+                <div class="community-actions community-actions--wrap">
+                    <a class="btn btn-primary btn-sm" href="/parties/create/">파티 생성</a>
+                    <a class="btn btn-secondary btn-sm" href="/parties/manage/">파티 관리</a>
+                </div>
+            </div>
             <div class="community-divider"></div>
             <div class="community-card-head">
                 <h2>받은 초대</h2>
                 <p>대기 중인 파티 초대를 바로 수락하거나 거절할 수 있습니다.</p>
             </div>
+            <div class="community-note" id="party-guest-note">게스트는 초대 수락 후 참가만 가능합니다.</div>
             <div class="community-sublist" id="party-invite-list"></div>
         </section>
-        <section class="community-card community-card--list">
+
+        <section class="community-card community-card--browse-main">
             <div class="community-card-head">
                 <h2>파티 목록</h2>
-                <p>단체전 대기 중인 파티를 확인합니다.</p>
+                <p>단체전 대기 중인 파티를 확인하고 바로 상세를 볼 수 있습니다.</p>
             </div>
-            <div class="community-list" id="party-list"></div>
-        </section>
-        <section class="community-card community-card--detail">
-            <div class="community-card-head">
-                <h2>파티 상세</h2>
-                <p id="party-detail-subtitle">파티를 선택하면 멤버, 준비 상태, 파티 채팅이 표시됩니다.</p>
-            </div>
+            <div class="community-sublist" id="party-list"></div>
+            <div class="community-divider"></div>
             <div id="party-detail-empty" class="community-empty">아직 선택한 파티가 없습니다.</div>
             <div id="party-detail-panel" class="community-detail hidden">
                 <div class="community-stack" id="party-summary"></div>

--- a/templates/community/parties_create.html
+++ b/templates/community/parties_create.html
@@ -1,0 +1,44 @@
+{% extends 'base.html' %}
+
+{% block title %}파티 생성 - ChessOK{% endblock %}
+
+{% block content %}
+<div class="community-page" id="party-page" data-view="create">
+    <section class="community-hero community-hero--split">
+        <div>
+            <h1>파티 생성</h1>
+            <p>3인 파티를 만들고 초대, 슬롯 배정, 라인업 고정까지 한 번에 준비할 수 있습니다.</p>
+        </div>
+        <div class="community-hero-actions">
+            <a class="btn btn-secondary btn-sm" href="/parties/">파티 둘러보기</a>
+            <a class="btn btn-secondary btn-sm" href="/parties/manage/">내 파티 관리</a>
+        </div>
+    </section>
+
+    <div class="community-grid community-grid--write">
+        <section class="community-card">
+            <div class="community-card-head">
+                <h2>새 파티 만들기</h2>
+                <p>파티를 만들면 바로 관리 화면으로 이어져 초대와 라인업 편집을 계속 진행할 수 있습니다.</p>
+            </div>
+            <div class="community-note" id="party-guest-note">게스트는 초대 수락 후 참가만 가능합니다.</div>
+            <form id="party-create-form" class="community-form">
+                <input class="form-input" name="title" placeholder="파티 이름" maxlength="60" required>
+                <textarea class="form-input" name="description" placeholder="파티 설명" rows="4"></textarea>
+                <div class="community-actions community-actions--wrap">
+                    <button class="btn btn-primary" type="submit">파티 생성</button>
+                    <a class="btn btn-secondary" href="/parties/">둘러보기로 돌아가기</a>
+                </div>
+            </form>
+        </section>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="/static/css/community.css">
+{% endblock %}
+
+{% block extra_js %}
+<script src="/static/js/pages/parties.js"></script>
+{% endblock %}


### PR DESCRIPTION


## 📝 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
  - 길드와 파티를 둘러보기 / 생성 / 내 관리 흐름으로 분리해, 탐색 화면과 운영 화면의 목적이 명확해졌습니다.
  - 길드/파티 생성 후 다시 목록으로 돌아와 찾을 필요 없이 바로 관리 화면으로 이어져 운영 흐름이 자연스러워졌습니다.
  - 길드 관리는 브랜딩 / 공지 / 멤버 관리 / 채팅 / 가입 요청 중심으로 정리되어 불필요한 운영 로그 없이 핵심 기능만 남게 됐습니다.
  - 길드 공지는 이력형으로 바뀌어 이전 공지를 계속 볼 수 있고, 작성 직후 이력과 요약에 즉시 반영되며 길드원 알림도 전송됩니다.
  - 전역 채팅은 로비 / 1:1 / 길드 / 파티 탭 구조로 확장돼 여러 채널을 한 패널 안에서 빠르게 오갈 수 있게 됐습니다.
  - 길드/파티 채팅에도 뒤로가기와 토글 흐름이 들어가 채팅 전환이 더 자연스러워졌습니다.
  - 게시판은 댓글 증분 로딩과 부분 갱신 구조로 바뀌어 글 상세 진입과 댓글 상호작용 시 전체 재렌더 부담이 줄었습니다.
  - 로비는 방 목록, 접속자, 게시판 미리보기를 통째로 갈아끼우는 비중을 줄이고 바뀐 항목만 패치하는 구조로 정리됐습니다.
  - 방 목록과 관전자 수 응답 경로는 annotated 값 재사용을 강화해 불필요한 count 조회와 목록 비용을 줄였습니다.
  - 게임 화면은 종료 요약, 분석, 기보, 채팅, 액션, 관전자/기물 패널을 분리해 메인 스크립트 과밀도를 낮추고 유지보수성을 높였습니다.
  - 보드 렌더/소켓/분석/리플레이 쪽 캐시와 helper 분리가 들어가 다시보기·분석·종료 화면 전환이 더 가볍게 동작합니다.
  - 모바일에서 화면이 꺼졌다가 돌아왔을 때도 최신 게임 상태를 다시 동기화하도록 보강돼, 상대 기권·종료 상태가 늦게 반영되던 문제가 줄었습니다.
  - 1:1 대국 화면은 보드 크기를 복구하고 우측 패널 공간 활용을 넓혀, 메뉴·채팅·기보 가독성이 더 좋아졌습니다.
  - 대전 메뉴는 세로로 눌려 보이지 않게 가로 비율과 설명 텍스트를 다시 잡았고, 플레이어 바와 우측 탭도 정보 밀도를 정리해 읽기 쉬워졌습니다.
  - 커스터마이징은 탭형 구조와 쇼룸 재배치로 긴 스크롤 부담을 줄였고, 모바일에서도 미리보기를 더 빨리 확인할 수 있게 바뀌었습니다.

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 (예: Closes #123) -->


## 📋 변경 타입
<!-- 해당하는 항목에 [x] 표시해주세요 -->

- [ ] 새로운 기능 (New Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation)
- [ ] 스타일 변경 (Style)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포 (Build/Deploy)
- [ ] 기타 (Other)

## ✅ 체크리스트
<!-- PR 제출 전에 확인해주세요 -->

- [ ] 로컬에서 테스트 완료
- [ ] 코드 포맷팅 적용 (`./scripts/format.sh`)
- [ ] 테스트 통과 (`./scripts/test.sh`)
- [ ] 마이그레이션 파일 포함 (필요한 경우)
- [ ] 문서 업데이트 (필요한 경우)

## 📸 스크린샷 (선택사항)
<!-- UI 변경이 있다면 스크린샷을 추가해주세요 -->


## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

