### PR TITLE
 [Refactor/minsoo] 길드·게임·커스터마이징 화면 정리: 모바일/레이아웃 보정, 실시간 복귀 동기화, 캐시 이슈 대응

### DIFF
--- a/static/css/customize.css
+++ b/static/css/customize.css
@@ -2,6 +2,8 @@
     max-width: 1260px;
     margin: 0 auto;
     padding: 24px 16px 40px;
+    min-width: 0;
+    overflow-x: clip;
 }
 
 .customize-header {
@@ -39,6 +41,7 @@
     display: grid;
     grid-template-columns: minmax(340px, 0.88fr) minmax(500px, 1.12fr);
     gap: 20px;
+    min-width: 0;
 }
 
 .customize-card {
@@ -48,6 +51,8 @@
         linear-gradient(180deg, color-mix(in srgb, var(--color-bg-card) 88%, white) 0%, color-mix(in srgb, var(--color-bg-secondary) 92%, transparent) 100%);
     padding: 22px;
     box-shadow: 0 18px 40px rgba(43, 42, 39, 0.08);
+    min-width: 0;
+    overflow: hidden;
 }
 
 .customize-points-card {
@@ -618,6 +623,11 @@
     grid-template-columns: 1fr;
     gap: 20px;
     align-items: start;
+    min-width: 0;
+}
+
+.customize-preview-showroom > * {
+    min-width: 0;
 }
 
 .customize-preview {
@@ -636,6 +646,7 @@
     box-shadow:
         inset 0 1px 0 rgba(255, 255, 255, 0.88),
         0 14px 28px rgba(43, 42, 39, 0.08);
+    min-width: 0;
 }
 
 .customize-preview-copy {
@@ -702,6 +713,7 @@
     display: grid;
     gap: 14px;
     justify-items: start;
+    min-width: 0;
 }
 
 .customize-skin-preview-title {
@@ -739,6 +751,7 @@
         linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(248, 243, 235, 0.82));
     display: grid;
     gap: 8px;
+    min-width: 0;
 }
 
 .customize-combo-spotlight[data-mode="matched"] {
@@ -1018,14 +1031,21 @@
 }
 
 @media (max-width: 768px) {
+    .customize-page {
+        padding: 14px 10px 28px;
+    }
+
     .customize-header {
         flex-direction: column;
+        gap: 12px;
     }
 
     .customize-header-side {
         width: 100%;
         justify-content: space-between;
         align-items: center;
+        gap: 10px;
+        flex-wrap: wrap;
     }
 
     .customize-section-head {
@@ -1037,7 +1057,65 @@
     }
 
     .customize-card {
-        padding: 18px;
+        padding: 16px;
+    }
+
+    .customize-preview-card-shell {
+        width: 100%;
+        padding: 14px;
+    }
+
+    .customize-preview {
+        grid-template-columns: 72px minmax(0, 1fr);
+        gap: 12px;
+        min-height: 0;
+        padding: 12px;
+    }
+
+    .customize-avatar {
+        width: 72px;
+        height: 72px;
+    }
+
+    .customize-nickname {
+        font-size: 1.02rem;
+    }
+
+    .customize-season-title {
+        margin-top: 4px;
+        padding: 5px 10px;
+        font-size: 0.7rem;
+    }
+
+    .customize-skin-preview-panel {
+        width: 100%;
+        justify-items: stretch;
+    }
+
+    .customize-skin-preview-board {
+        width: min(100%, 280px);
+        max-width: 100%;
+        margin: 0 auto;
+        height: auto;
+    }
+
+    .customize-combo-head {
+        align-items: stretch;
+    }
+
+    .customize-combo-badges {
+        width: 100%;
+    }
+
+    .customize-combo-spotlight strong,
+    .customize-combo-spotlight p,
+    .customize-skin-meta-item strong,
+    .customize-skin-meta-item span,
+    .customize-preview-mini-subtitle,
+    .customize-section-copy,
+    .customize-subtitle {
+        word-break: break-word;
+        overflow-wrap: anywhere;
     }
 
     .customize-shop-tabs {

--- a/static/js/pages/guilds.js
+++ b/static/js/pages/guilds.js
@@ -231,6 +231,9 @@
         document.getElementById('guild-transfer-btn')?.toggleAttribute('disabled', !isLeader());
         document.getElementById('guild-kick-btn')?.toggleAttribute('disabled', !isManager());
         guildNoticeInput?.toggleAttribute('disabled', !isManager());
+        if (guildNoticeInput && document.activeElement !== guildNoticeInput) {
+            guildNoticeInput.value = guild.notice || '';
+        }
         renderMemberSelection();
         setChatPanelExpanded(window.innerWidth > 768);
     }

--- a/templates/chess/game.html
+++ b/templates/chess/game.html
@@ -334,9 +334,9 @@
 /* Game Container */
 .game-container {
     display: grid;
-    grid-template-columns: minmax(700px, 760px) minmax(720px, 1fr);
+    grid-template-columns: minmax(620px, 720px) minmax(420px, 1fr);
     gap: var(--space-lg);
-    max-width: 1760px;
+    max-width: 1680px;
     width: 100%;
     margin: 0 auto;
     padding: var(--space-sm) var(--space-md);
@@ -1675,7 +1675,7 @@ html[data-theme="dark"] .piece.white {
 
 .panel-top-grid {
     display: grid;
-    grid-template-columns: minmax(320px, 360px) minmax(440px, 1fr);
+    grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
     gap: clamp(0.75rem, 1.2vw, var(--space-md));
     align-items: start;
 }
@@ -1983,12 +1983,12 @@ html[data-theme="dark"] .piece.white {
 
 @media (max-width: 1500px) {
     .game-container {
-        grid-template-columns: minmax(640px, 720px) minmax(580px, 1fr);
-        max-width: 1480px;
+        grid-template-columns: minmax(560px, 680px) minmax(360px, 1fr);
+        max-width: 1440px;
     }
 
     .panel-top-grid {
-        grid-template-columns: minmax(300px, 336px) minmax(360px, 1fr);
+        grid-template-columns: minmax(200px, 228px) minmax(0, 1fr);
     }
 }
 

--- a/templates/community/guilds.html
+++ b/templates/community/guilds.html
@@ -60,5 +60,5 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="/static/js/pages/guilds.js"></script>
+<script src="/static/js/pages/guilds.js?v=20260424-2"></script>
 {% endblock %}

--- a/templates/community/guilds_create.html
+++ b/templates/community/guilds_create.html
@@ -50,5 +50,5 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="/static/js/pages/guilds.js"></script>
+<script src="/static/js/pages/guilds.js?v=20260424-2"></script>
 {% endblock %}

--- a/templates/community/guilds_manage.html
+++ b/templates/community/guilds_manage.html
@@ -130,5 +130,5 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="/static/js/pages/guilds.js"></script>
+<script src="/static/js/pages/guilds.js?v=20260424-2"></script>
 {% endblock %}


### PR DESCRIPTION
## 📝 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
  - 길드와 파티는 둘러보기 / 생성 / 내 관리 흐름으로 분리되어, 탐색 화면과 운영 화면의 목적이 더 분명해졌습니다.
  - 길드 관리에서는 브랜딩, 공지, 멤버 관리, 길드 채팅, 가입 요청만 남겨 핵심 운영 기능 중심으로 정리됐습니다.
  - 길드 공지는 이력형으로 바뀌어 이전 공지를 계속 볼 수 있고, 저장 즉시 이력과 요약에 반영되며 길드원 알림도 전송됩니다.
  - 길드 화면에서 모바일로 진입할 때 뜨던 guildNoticeInput null 오류는 DOM 가드와 스크립트 캐시 무효화를 같이 넣어 정리됐습니다.
  - 길드 관련 browse/manage/create 3개 화면은 새 버전 JS를 보도록 바뀌어, iPhone Safari에 남아 있던 예전 캐시까지 갱신되게 됐습니다.
  - 길드 목록 카드는 아바타와 텍스트 레이아웃을 다시 잡아, 데스크톱에서도 제목과 메타가 눌리거나 잘려 보이던 문제가 줄었습니다.
  - 커스터마이징은 길게 아래로 내리는 구조 대신 탭형으로 바뀌어, 필요한 항목만 바로 선택할 수 있게 됐습니다.
  - 쇼룸 미리보기는 프로필 카드와 보드 미리보기 비율을 다시 잡아, 데스크톱과 모바일 모두에서 잘림과 밀림이 줄었습니다.
  - 모바일 커스터마이징은 쇼룸 전체를 1열 기준으로 다시 정리하고, 추천 조합/설명/메타도 안전하게 줄바꿈되도록 보강했습니다.
  - 전역 채팅은 로비 / 1:1 / 길드 / 파티 탭 구조로 확장되어 여러 채널을 한 패널 안에서 빠르게 오갈 수 있게 됐습니다.
  - 길드/파티 채팅에는 뒤로가기와 토글 흐름이 추가되어, 1:1 채팅처럼 자연스럽게 복귀할 수 있게 됐습니다.
  - 게임 화면은 보드 크기를 복구하고 우측 패널 공간 활용을 넓혀, 대전 메뉴·채팅·기보가 가운데에 낑기지 않도록 다시 정리됐습니다.
  - 대전 메뉴는 세로로 눌려 읽기 어렵던 상태에서 벗어나 가로 비율과 설명 텍스트가 더 읽기 좋게 바뀌었습니다.
  - 모바일에서 화면이 꺼졌다가 돌아왔을 때도 최신 게임 상태를 다시 동기화하도록 보강돼, 상대 기권이나 종료 상태가 늦게 반영되던 문제가 줄었습니다.
  - 전체적으로 이번 작업은 길드/파티 관리 흐름 분리, 커스터마이징 스크롤 부담 완화, 게임 화면 비율 복구, 모바일 오류 및 캐시 이슈 대응까지 묶어서 화면 안정성과 체감 UX를 끌어올린 정리 작업입니다.

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 (예: Closes #123) -->


## 📋 변경 타입
<!-- 해당하는 항목에 [x] 표시해주세요 -->

- [ ] 새로운 기능 (New Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation)
- [ ] 스타일 변경 (Style)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포 (Build/Deploy)
- [ ] 기타 (Other)

## ✅ 체크리스트
<!-- PR 제출 전에 확인해주세요 -->

- [ ] 로컬에서 테스트 완료
- [ ] 코드 포맷팅 적용 (`./scripts/format.sh`)
- [ ] 테스트 통과 (`./scripts/test.sh`)
- [ ] 마이그레이션 파일 포함 (필요한 경우)
- [ ] 문서 업데이트 (필요한 경우)

## 📸 스크린샷 (선택사항)
<!-- UI 변경이 있다면 스크린샷을 추가해주세요 -->


## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

