### PR TITLE
[Refactor/minsoo] 게임·길드·커스터마이징 화면 안정화: 레이아웃 복구, 모바일 오류 정리, 관리 흐름 분리

### DIFF
--- a/apps/chess/services/room_state_service.py
+++ b/apps/chess/services/room_state_service.py
@@ -22,6 +22,13 @@ class RoomStateService:
         if cached is not None:
             return cached
 
+        prefetched = getattr(room, "_prefetched_objects_cache", None) or {}
+        spectators = prefetched.get("spectators")
+        if spectators is not None:
+            count = len(spectators)
+            room._spectator_count_cache = count
+            return count
+
         count = room.spectators.count()
         room._spectator_count_cache = count
         return count

--- a/static/css/community.css
+++ b/static/css/community.css
@@ -106,6 +106,7 @@
 .community-card-head {
     display: grid;
     gap: 0.25rem;
+    min-width: 0;
 }
 
 .community-card--board-detail .community-card-head {
@@ -348,6 +349,7 @@
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
+    min-width: 0;
 }
 
 .community-actions--wrap,
@@ -355,6 +357,7 @@
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
+    min-width: 0;
 }
 
 .community-inline-form--end {
@@ -556,6 +559,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 0.6rem;
+    min-width: 0;
 }
 
 .community-row--start {
@@ -624,6 +628,18 @@
     display: grid;
     gap: 0.5rem;
     min-width: 0;
+}
+
+.community-detail,
+.community-hero-actions,
+.community-item-head {
+    min-width: 0;
+}
+
+.community-actions .btn,
+.community-inline-form .btn,
+.community-hero-actions .btn {
+    max-width: 100%;
 }
 
 .community-block--tight {
@@ -831,6 +847,10 @@
         gap: 0.85rem;
     }
 
+    .community-hero {
+        padding-top: 1rem;
+    }
+
     .community-hero--split {
         flex-direction: column;
         align-items: start;
@@ -865,6 +885,11 @@
         gap: 0.82rem;
     }
 
+    .community-actions,
+    .community-inline-form {
+        gap: 0.45rem;
+    }
+
     .community-guild-row,
     #guild-list .community-guild-row--list,
     .community-member-main {
@@ -892,9 +917,12 @@
 
     .community-inline-form .btn,
     .community-actions--wrap .btn,
-    .community-form-compact .btn {
+    .community-form-compact .btn,
+    .community-actions .btn,
+    .community-hero-actions .btn {
         width: 100%;
         justify-content: center;
+        min-height: 42px;
     }
 
     .community-selection-bar,
@@ -920,6 +948,14 @@
         align-items: flex-start;
         flex-wrap: wrap;
     }
+
+    .community-row-meta,
+    .community-guild-list-meta,
+    .community-item-meta,
+    .community-item-copy,
+    .community-note {
+        overflow-wrap: anywhere;
+    }
 }
 
 @media (max-width: 640px) {
@@ -938,6 +974,10 @@
 
     .community-card {
         padding: 0.85rem;
+    }
+
+    .community-file-field .form-input[type='file'] {
+        font-size: 0.9rem;
     }
 
     .community-card-head p,

--- a/static/js/components/game_modal_ui.js
+++ b/static/js/components/game_modal_ui.js
@@ -1,0 +1,116 @@
+(function() {
+    'use strict';
+
+    function setupStatusModal({ statusModal, statusModalOk }) {
+        if (!statusModalOk) return;
+        statusModalOk.addEventListener('click', () => {
+            statusModal?.classList.add('hidden');
+        });
+    }
+
+    function showStatusModal({ statusModal, statusModalMessage, message, autoCloseMs = null }) {
+        if (!statusModal || !statusModalMessage) return;
+        statusModalMessage.textContent = message;
+        statusModal.classList.remove('hidden');
+        if (autoCloseMs) {
+            setTimeout(() => {
+                statusModal.classList.add('hidden');
+            }, autoCloseMs);
+        }
+    }
+
+    function showPendingEnd({ gameEndModal, message }) {
+        if (!gameEndModal) return;
+        gameEndModal.classList.remove('outcome-win', 'outcome-loss', 'outcome-draw');
+        const iconEl = document.getElementById('game-end-icon');
+        const titleEl = document.getElementById('game-end-title');
+        const resultEl = document.getElementById('game-end-result');
+        const ratingEl = document.getElementById('game-end-rating');
+
+        if (iconEl) iconEl.textContent = '⏳';
+        if (titleEl) titleEl.textContent = '처리 중...';
+        if (resultEl) resultEl.textContent = message;
+        if (ratingEl) ratingEl.textContent = '';
+
+        gameEndModal.classList.remove('hidden');
+        gameEndModal.style.display = 'flex';
+    }
+
+    function applyGameEndPresentation({
+        gameEndModal,
+        result,
+        myColor,
+        getOutcome,
+        analysisLoading,
+        analysisContent,
+        analysisSummary,
+    }) {
+        if (!gameEndModal) return;
+        gameEndModal.classList.remove('outcome-win', 'outcome-loss', 'outcome-draw');
+
+        const iconEl = document.getElementById('game-end-icon');
+        const titleEl = document.getElementById('game-end-title');
+        const resultEl = document.getElementById('game-end-result');
+
+        if (analysisLoading) analysisLoading.classList.remove('hidden');
+        if (analysisContent) analysisContent.classList.add('hidden');
+        if (analysisSummary) analysisSummary.textContent = '';
+
+        let icon = '🎮';
+        let title = '게임 종료';
+        let resultText = result;
+
+        const outcome = getOutcome(result, myColor);
+        const isWin = outcome === 'win';
+
+        if (result.includes('checkmate')) {
+            icon = isWin ? '👑' : '💀';
+            title = isWin ? '승리!' : '패배';
+            resultText = '체크메이트';
+        } else if (result.includes('resignation')) {
+            if (outcome === 'win') {
+                icon = '🏆';
+                title = '승리!';
+                resultText = '상대 기권';
+            } else if (outcome === 'loss') {
+                icon = '🏳️';
+                title = '패배';
+                resultText = '내 기권';
+            } else {
+                icon = '🏳️';
+                title = '패배';
+                resultText = '기권';
+            }
+        } else if (result.includes('timeout')) {
+            icon = isWin ? '⏰' : '⏱️';
+            title = isWin ? '승리!' : '패배';
+            resultText = '시간 초과';
+        } else if (result.includes('draw') || result === 'stalemate') {
+            icon = '🤝';
+            title = '무승부';
+            resultText = result === 'stalemate' ? '스테일메이트' : '합의 무승부';
+        }
+
+        if (outcome === 'win') {
+            gameEndModal.classList.add('outcome-win');
+        } else if (outcome === 'loss') {
+            gameEndModal.classList.add('outcome-loss');
+        } else if (outcome === 'draw') {
+            gameEndModal.classList.add('outcome-draw');
+        }
+
+        if (iconEl) iconEl.textContent = icon;
+        if (titleEl) titleEl.textContent = title;
+        if (resultEl) resultEl.textContent = resultText;
+
+        gameEndModal.classList.remove('hidden');
+        gameEndModal.style.display = 'flex';
+    }
+
+    window.GameModalUI = {
+        setupStatusModal,
+        showStatusModal,
+        showPendingEnd,
+        applyGameEndPresentation,
+    };
+})();

--- a/static/js/components/game_panel_ui.js
+++ b/static/js/components/game_panel_ui.js
@@ -1,0 +1,160 @@
+(function() {
+    'use strict';
+
+    function setActiveSidePanelTab({ sidePanelTabs, sectionId }) {
+        sidePanelTabs.forEach((button) => {
+            const isActive = button.dataset.panelTarget === sectionId;
+            button.classList.toggle('is-active', isActive);
+            button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+    }
+
+    function focusSidePanelSection({
+        sidePanel,
+        sidePanelTabs,
+        sectionId,
+        onSetActiveSection,
+    }) {
+        if (!sidePanel || !sectionId) return;
+        const section = document.getElementById(sectionId);
+        if (!section) return;
+        const header = section.querySelector('.panel-header');
+        if (header && section.classList.contains('is-collapsed')) {
+            header.click();
+        } else {
+            onSetActiveSection?.(sectionId);
+            setActiveSidePanelTab({ sidePanelTabs, sectionId });
+        }
+        requestAnimationFrame(() => {
+            section.scrollIntoView({
+                behavior: 'smooth',
+                block: window.innerWidth <= 1360 ? 'start' : 'nearest',
+            });
+        });
+    }
+
+    function syncChatFabVisibility({ chatFab, chatSection }) {
+        if (!chatFab || !chatSection) return;
+        const isMobile = window.innerWidth <= 768;
+        if (!isMobile) {
+            chatFab.classList.remove('hidden');
+            return;
+        }
+        const chatVisible = !chatSection.classList.contains('is-collapsed') && !chatSection.classList.contains('is-hidden');
+        chatFab.classList.toggle('hidden', chatVisible);
+    }
+
+    function setupChatToggle({
+        chatFab,
+        chatSection,
+        chatCloseBtn,
+        onSetActiveSection,
+        onSyncVisibility,
+        onOpen,
+    }) {
+        if (!chatFab || !chatSection) return;
+        chatSection.classList.add('is-collapsed');
+        onSyncVisibility?.();
+        chatFab.addEventListener('click', () => {
+            Utils?.Sounds?.unlock?.();
+            const willOpen = chatSection.classList.contains('is-collapsed');
+            chatSection.classList.toggle('is-collapsed');
+            chatSection.classList.toggle('is-floating', willOpen);
+            chatFab.classList.toggle('is-active', willOpen);
+            onSyncVisibility?.();
+            if (willOpen) {
+                onSetActiveSection?.('game-chat-section');
+                onOpen?.();
+            }
+        });
+        chatCloseBtn?.addEventListener('click', () => {
+            chatSection.classList.add('is-collapsed');
+            chatSection.classList.remove('is-floating');
+            chatFab.classList.remove('is-active');
+            onSetActiveSection?.('game-moves-section');
+            onSyncVisibility?.();
+        });
+    }
+
+    function setupSidePanelAccordion({
+        sidePanel,
+        sidePanelTabs,
+        getActiveSectionId,
+        setActiveSectionId,
+        storageKey,
+        defaultStates,
+        isNarrow,
+        onSyncVisibility,
+    }) {
+        if (!sidePanel) return;
+        const sections = Array.from(sidePanel.querySelectorAll('.panel-section'));
+        if (!sections.length) return;
+
+        const getSavedStates = () => Utils.Storage.get(storageKey, { ...defaultStates }) || { ...defaultStates };
+        const saveStates = (states) => Utils.Storage.set(storageKey, states);
+
+        const setCollapsed = (section, collapsed) => {
+            const header = section.querySelector('.panel-header');
+            section.classList.toggle('is-collapsed', collapsed);
+            section.dataset.collapsed = collapsed ? 'true' : 'false';
+            if (header) {
+                header.dataset.accordionLabel = collapsed ? '닫힘' : '열림';
+                header.classList.add('is-clickable');
+            }
+        };
+
+        const applyLayout = () => {
+            const narrow = isNarrow();
+            const states = getSavedStates();
+            sidePanel.classList.add('is-accordion');
+            sections.forEach((section) => {
+                const header = section.querySelector('.panel-header');
+                if (!header) return;
+                const collapsed = Boolean(states[section.id]);
+                setCollapsed(section, collapsed);
+                header.dataset.accordionMode = narrow ? 'single' : 'multi';
+            });
+            if (states[getActiveSectionId()]) {
+                setActiveSectionId(narrow ? 'game-actions' : 'game-moves-section');
+            }
+            setActiveSidePanelTab({ sidePanelTabs, sectionId: getActiveSectionId() });
+            onSyncVisibility?.();
+        };
+
+        sections.forEach((section) => {
+            const header = section.querySelector('.panel-header');
+            if (!header || header.dataset.accordionBound === '1') return;
+            header.dataset.accordionBound = '1';
+            header.addEventListener('click', () => {
+                const states = getSavedStates();
+                const nextCollapsed = !section.classList.contains('is-collapsed');
+                if (isNarrow() && !nextCollapsed) {
+                    sections.forEach((target) => {
+                        if (target.id === section.id) return;
+                        states[target.id] = true;
+                        setCollapsed(target, true);
+                    });
+                }
+                states[section.id] = nextCollapsed;
+                setCollapsed(section, nextCollapsed);
+                saveStates(states);
+                if (!nextCollapsed) {
+                    setActiveSectionId(section.id);
+                    setActiveSidePanelTab({ sidePanelTabs, sectionId: section.id });
+                }
+                onSyncVisibility?.();
+            });
+        });
+
+        applyLayout();
+        window.addEventListener('resize', Utils.debounce(applyLayout, 120));
+    }
+
+    window.GamePanelUI = {
+        setActiveSidePanelTab,
+        focusSidePanelSection,
+        syncChatFabVisibility,
+        setupChatToggle,
+        setupSidePanelAccordion,
+    };
+})();

--- a/static/js/components/game_status_ui.js
+++ b/static/js/components/game_status_ui.js
@@ -1,0 +1,276 @@
+(function() {
+    'use strict';
+
+    function renderPlayerBars({
+        game,
+        myColor,
+        opponentBar,
+        myBar,
+    }) {
+        if (!game) return;
+
+        const whitePlayer = game.white_player;
+        const blackPlayer = game.black_player;
+        const isFlipped = myColor === 'black';
+        const topPlayer = isFlipped ? whitePlayer : blackPlayer;
+        const bottomPlayer = isFlipped ? blackPlayer : whitePlayer;
+
+        renderPlayerBar({
+            container: opponentBar,
+            player: topPlayer,
+            fallbackName: '상대',
+            nicknameColor: Utils.getNicknameColorValue(topPlayer?.nickname_color || ''),
+            profileRing: Utils.getProfileBorderValue(topPlayer?.profile_border || ''),
+            tier: topPlayer?.rank_tier || 'Junior',
+            timerId: 'opponent-timer',
+        });
+
+        renderPlayerBar({
+            container: myBar,
+            player: bottomPlayer,
+            fallbackName: '나',
+            nicknameColor: Utils.getNicknameColorValue(bottomPlayer?.nickname_color || ''),
+            profileRing: Utils.getProfileBorderValue(bottomPlayer?.profile_border || ''),
+            tier: bottomPlayer?.rank_tier || 'Junior',
+            timerId: 'my-timer',
+        });
+    }
+
+    function renderPlayerBar({
+        container,
+        player,
+        fallbackName,
+        nicknameColor,
+        profileRing,
+        tier,
+        timerId,
+    }) {
+        if (!container) return;
+        container.textContent = '';
+
+        const info = document.createElement('div');
+        info.className = 'player-bar-info';
+
+        const avatar = document.createElement('div');
+        avatar.className = 'avatar avatar-sm';
+        if (profileRing) avatar.style.boxShadow = profileRing;
+        Utils.setAvatar(avatar, {
+            url: player?.avatar_url,
+            alt: player?.nickname || fallbackName,
+            placeholder: '?',
+            placeholderClass: 'avatar-placeholder',
+        });
+        info.appendChild(avatar);
+
+        const details = document.createElement('div');
+        details.className = 'player-bar-details';
+
+        const name = document.createElement('span');
+        name.className = 'player-bar-name';
+        if (nicknameColor) name.style.color = nicknameColor;
+        name.appendChild(document.createTextNode(player?.nickname || fallbackName));
+        name.appendChild(document.createTextNode(' '));
+        const badge = document.createElement('span');
+        badge.className = 'tier-badge';
+        badge.title = tier || '';
+        badge.textContent = Utils.getTierIcon(tier || '');
+        name.appendChild(badge);
+        details.appendChild(name);
+
+        const rating = document.createElement('span');
+        rating.className = 'player-bar-rating';
+        rating.textContent = String(player?.rating || '--');
+        details.appendChild(rating);
+
+        if (player?.featured_achievement?.title) {
+            const achievement = document.createElement('span');
+            achievement.className = `player-bar-achievement player-bar-achievement--${player.featured_achievement.tone || 'info'}`;
+            achievement.textContent = `${player.featured_achievement.icon || '🏅'} ${player.featured_achievement.title}`;
+            details.appendChild(achievement);
+        }
+
+        info.appendChild(details);
+        container.appendChild(info);
+
+        const timer = document.createElement('div');
+        timer.className = 'player-bar-timer';
+        timer.id = timerId;
+        timer.textContent = '--:--';
+        container.appendChild(timer);
+    }
+
+    function setUiStateBadge(element, tone, text) {
+        if (!element) return;
+        const nextClass = ['ui-state-badge'];
+        if (tone === 'success') nextClass.push('ui-state-badge--success');
+        if (tone === 'pending') nextClass.push('ui-state-badge--pending');
+        if (tone === 'warning') nextClass.push('ui-state-badge--warning');
+        element.className = nextClass.join(' ');
+        element.textContent = text;
+    }
+
+    function getModeBadgeText({ game, replayOnly, isAiRoom, myColor }) {
+        if (replayOnly) return '기보 다시보기';
+        if (!game) return '실시간 대국';
+        if (isAiRoom) return 'AI 대전';
+        if (!myColor) return '관전 중';
+        if (game.room_type === 'competitive') return '경쟁전';
+        if (game.room_type === 'quick') return '빠른 대전';
+        return '실시간 대국';
+    }
+
+    function updateStatusStrip({
+        game,
+        replayOnly,
+        isAiRoom,
+        myColor,
+        isMyTurn,
+        lastMove,
+        gameModeBadge,
+        gameTurnBadge,
+        gameAlertBadge,
+        getOutcome,
+    }) {
+        if (!game) return;
+
+        const modeTone = replayOnly ? 'warning' : (!myColor ? 'pending' : 'success');
+        setUiStateBadge(
+            gameModeBadge,
+            modeTone,
+            getModeBadgeText({ game, replayOnly, isAiRoom, myColor })
+        );
+
+        if (game.result && game.result !== 'playing') {
+            const outcome = getOutcome(game.result, myColor);
+            if (outcome === 'win') {
+                setUiStateBadge(gameTurnBadge, 'success', '결과: 승리');
+            } else if (outcome === 'loss') {
+                setUiStateBadge(gameTurnBadge, 'warning', '결과: 패배');
+            } else if (outcome === 'draw') {
+                setUiStateBadge(gameTurnBadge, 'pending', '결과: 무승부');
+            } else {
+                setUiStateBadge(gameTurnBadge, '', '결과 확정');
+            }
+        } else if (!myColor) {
+            setUiStateBadge(gameTurnBadge, 'pending', game.current_turn === 'white' ? '백 차례' : '흑 차례');
+        } else {
+            setUiStateBadge(gameTurnBadge, isMyTurn ? 'success' : '', isMyTurn ? '내 차례' : '상대 차례');
+        }
+
+        if (lastMove?.is_checkmate) {
+            setUiStateBadge(gameAlertBadge, 'warning', '체크메이트');
+        } else if (lastMove?.is_check && game.result === 'playing') {
+            setUiStateBadge(
+                gameAlertBadge,
+                'warning',
+                !myColor ? '체크 발생' : (game.current_turn === myColor ? '체크 경고' : '상대 킹 체크')
+            );
+        } else if (replayOnly) {
+            setUiStateBadge(gameAlertBadge, '', '기보를 단계별로 다시볼 수 있습니다');
+        } else if (!myColor) {
+            setUiStateBadge(gameAlertBadge, '', '우측 패널에서 기보·관전자·채팅 확인');
+        } else {
+            setUiStateBadge(gameAlertBadge, '', '우측 패널에서 기보·채팅·액션 확인');
+        }
+    }
+
+    function updateTurnPresentation({
+        game,
+        myColor,
+        isMyTurn,
+        opponentBar,
+        myBar,
+        gameActions,
+        turnIndicator,
+        hasShownStartGuide,
+        showStatusModal,
+    }) {
+        if (!game) {
+            return { hasShownStartGuide };
+        }
+
+        const isFlipped = myColor === 'black';
+        const isWhiteTurn = game.current_turn === 'white';
+        const isTopPlayerTurn = isFlipped ? isWhiteTurn : !isWhiteTurn;
+
+        opponentBar?.classList.toggle('active', isTopPlayerTurn);
+        myBar?.classList.toggle('active', !isTopPlayerTurn);
+
+        if (!myColor && gameActions) {
+            gameActions.style.display = 'none';
+        }
+
+        const whiteName = game.white_player?.nickname || '화이트';
+        const blackName = game.black_player?.nickname || '블랙';
+        const currentName = game.current_turn === 'white' ? whiteName : blackName;
+
+        if (turnIndicator) {
+            if (!hasShownStartGuide && game.move_count === 0) {
+                turnIndicator.textContent = `${currentName}님부터 시작합니다. 번갈아가며 한 번씩 수를 둡니다.`;
+            } else {
+                turnIndicator.textContent = `지금은 ${currentName}님의 차례입니다.`;
+            }
+        }
+
+        if (!hasShownStartGuide && game.move_count === 0) {
+            showStatusModal?.(`${currentName}님부터 시작합니다. 번갈아가며 한 번씩 수를 둡니다.`, 2500);
+            hasShownStartGuide = true;
+        }
+
+        return { hasShownStartGuide };
+    }
+
+    function getLiveTimeSnapshot({ game }) {
+        if (!game) {
+            return { white: 0, black: 0 };
+        }
+        let white = Number(game.white_time_remaining || 0);
+        let black = Number(game.black_time_remaining || 0);
+        if (game.result === 'playing' && game.turn_started_at) {
+            const startedAt = new Date(game.turn_started_at).getTime();
+            if (!Number.isNaN(startedAt)) {
+                const elapsed = Math.max(0, (Date.now() - startedAt) / 1000);
+                if (game.current_turn === 'white') {
+                    white = Math.max(0, white - elapsed);
+                } else {
+                    black = Math.max(0, black - elapsed);
+                }
+            }
+        }
+        return { white, black };
+    }
+
+    function updateTimerDisplay({
+        game,
+        myColor,
+        opponentBar,
+        myBar,
+    }) {
+        if (!game) return;
+
+        const isFlipped = myColor === 'black';
+        const liveTimes = getLiveTimeSnapshot({ game });
+        const topTime = isFlipped ? liveTimes.white : liveTimes.black;
+        const bottomTime = isFlipped ? liveTimes.black : liveTimes.white;
+
+        const opponentTimerEl = opponentBar?.querySelector('.player-bar-timer');
+        const myTimerEl = myBar?.querySelector('.player-bar-timer');
+
+        if (opponentTimerEl) {
+            opponentTimerEl.textContent = Utils.formatTime(topTime);
+            opponentTimerEl.classList.toggle('low', topTime < 30);
+        }
+        if (myTimerEl) {
+            myTimerEl.textContent = Utils.formatTime(bottomTime);
+            myTimerEl.classList.toggle('low', bottomTime < 30);
+        }
+    }
+
+    window.GameStatusUI = {
+        renderPlayerBars,
+        updateStatusStrip,
+        updateTurnPresentation,
+        getLiveTimeSnapshot,
+        updateTimerDisplay,
+    };
+})();

--- a/static/js/components/global_dm.js
+++ b/static/js/components/global_dm.js
@@ -32,6 +32,7 @@
         guild: 0,
         party: 0,
     };
+    let directUnreadMap = {};
     const messageRenderState = {
         direct: { signature: '', ids: [] },
         guild: { signature: '', ids: [] },
@@ -388,7 +389,11 @@
         roomSubtitle.textContent = '';
         
         loadTargetInfo(userId);
-        loadMessages(true);
+        await loadMessages(true);
+        if (directUnreadMap[userId]) {
+            await markDirectMessageNotificationsRead(userId);
+            directUnreadMap[userId] = 0;
+        }
         startRoomPolling();
     }
 
@@ -491,6 +496,7 @@
             
             const threads = data.results || [];
             const unreadMap = dmUI.buildUnreadMap(notifications.results || []);
+            directUnreadMap = unreadMap;
             
             dmUI.updateGlobalBadge(fabBadge, unreadMap);
             tabUnread.direct = Object.values(unreadMap).reduce((acc, value) => acc + value, 0);
@@ -679,15 +685,12 @@
                     const lastItem = orderedItems[orderedItems.length - 1];
                     if (lastItem.sender?.id !== currentUser?.id) {
                         Utils?.Sounds?.chat?.();
+                        await markDirectMessageNotificationsRead(currentRoomUserId);
+                        directUnreadMap[currentRoomUserId] = 0;
                     }
                 }
             }
             lastMessageCount = data.count || 0;
-            
-            // Mark read if panel is open and focused
-            if (!panel.classList.contains('hidden')) {
-                markDirectMessageNotificationsRead(currentRoomUserId);
-            }
         } catch (e) {
             console.error('Failed to load messages:', e);
             dmUI.setMessagesEmpty(messagesEl, messageRenderState.direct, '메시지를 불러오지 못했습니다.');

--- a/static/js/pages/admin.js
+++ b/static/js/pages/admin.js
@@ -50,6 +50,8 @@
     const forceDeleteBtn = document.getElementById('force-delete-btn');
 
     let selectedUser = null;
+    let opsPoller = null;
+    let lastOpsSignature = '';
 
     init();
 
@@ -58,10 +60,10 @@
         await loadUsers();
         await loadReports();
         await loadAiSettings();
-        await loadOpsReport();
         setupActions();
         setupMobileTabs();
-        window.setInterval(loadOpsReport, 30000);
+        await loadOpsReport({ force: true, showLoading: true });
+        startOpsPolling();
     }
 
     async function loadStats() {
@@ -356,7 +358,7 @@
         });
 
         opsRefreshBtn?.addEventListener('click', async () => {
-            await loadOpsReport();
+            await loadOpsReport({ force: true, showLoading: true });
             Toast.success('운영 리포트를 새로고침했습니다.');
         });
     }
@@ -426,21 +428,35 @@
                 tab.classList.add('active');
                 document.body.classList.remove('admin-tab-users', 'admin-tab-reports', 'admin-tab-ops');
                 document.body.classList.add(`admin-tab-${target || 'users'}`);
+                if ((target || 'users') === 'ops') {
+                    opsPoller?.trigger?.();
+                }
             });
         });
     }
 
-    async function loadOpsReport() {
+    async function loadOpsReport(options = {}) {
+        const { force = false, showLoading = false } = options;
         if (!opsOverallStatus || !opsComponentGrid || !opsMetricGrid) return;
 
-        opsOverallStatus.textContent = '로딩 중';
-        opsOverallStatus.className = 'ops-status-badge is-loading';
+        if (showLoading) {
+            opsOverallStatus.textContent = '로딩 중';
+            opsOverallStatus.className = 'ops-status-badge is-loading';
+        }
 
         try {
             const data = await API.get('/admin/ops/');
+            const nextSignature = JSON.stringify({
+                status: data.status || 'unknown',
+                components: data.components || {},
+                metrics: data.metrics || {},
+            });
             renderOpsSummary(data);
-            renderOpsComponents(data.components || {});
-            renderOpsMetrics(data.metrics || {});
+            if (force || nextSignature !== lastOpsSignature) {
+                renderOpsComponents(data.components || {});
+                renderOpsMetrics(data.metrics || {});
+                lastOpsSignature = nextSignature;
+            }
         } catch (error) {
             opsOverallStatus.textContent = '오류';
             opsOverallStatus.className = 'ops-status-badge is-error';
@@ -448,6 +464,25 @@
             opsComponentGrid.innerHTML = '<div class="admin-section-note">운영 상태를 불러오지 못했습니다.</div>';
             opsMetricGrid.innerHTML = '<div class="admin-section-note">운영 메트릭을 불러오지 못했습니다.</div>';
         }
+    }
+
+    function isOpsPanelVisible() {
+        const isMobile = window.innerWidth <= 768 && adminTabs.length > 0;
+        if (!isMobile) return true;
+        return document.body.classList.contains('admin-tab-ops');
+    }
+
+    function startOpsPolling() {
+        if (!opsOverallStatus || !window.Utils?.createAdaptivePoller) return;
+        opsPoller?.stop?.();
+        opsPoller = Utils.createAdaptivePoller({
+            callback: () => loadOpsReport(),
+            activeInterval: 30000,
+            hiddenInterval: 90000,
+            enabled: () => isOpsPanelVisible(),
+            immediate: false,
+        });
+        opsPoller.start();
     }
 
     function renderOpsSummary(data) {
@@ -558,4 +593,19 @@
         };
         return labels[value] || value.replace(/_/g, ' ');
     }
+
+    window.addEventListener('beforeunload', () => {
+        opsPoller?.stop?.();
+        opsPoller = null;
+    });
+    window.addEventListener('focus', () => {
+        if (!document.hidden && isOpsPanelVisible()) {
+            opsPoller?.trigger?.();
+        }
+    });
+    document.addEventListener('visibilitychange', () => {
+        if (!document.hidden && isOpsPanelVisible()) {
+            opsPoller?.trigger?.();
+        }
+    });
 })();

--- a/static/js/pages/game.js
+++ b/static/js/pages/game.js
@@ -29,6 +29,7 @@
     });
     const boardUI = window.GameBoardUI;
     const socketClient = window.GameSocketClient;
+    const statusUI = window.GameStatusUI;
 
     // DOM Elements
     const chessBoard = document.getElementById('chess-board');
@@ -122,7 +123,6 @@
     let timerInterval = null;
     let heartbeatInterval = null;
     let hasShownStartGuide = false;
-    let lastTurnColor = null;
     let lastMove = null;
     let replayMoves = [];
     let replayIndex = 0;
@@ -160,6 +160,7 @@
     let lastMoveListSignature = null;
     let activeSidePanelSectionId = window.innerWidth <= 900 ? 'game-actions' : 'game-moves-section';
     const pieceSvgMarkupCache = new Map();
+    let currentUserReadyPromise = null;
 
     function showStatus(message, type = 'info', duration = 1800) {
         if (window.StatusBadge) {
@@ -215,23 +216,8 @@
         }
         injectPieceSpriteStyles();
 
-        try {
-            currentUser = await API.get('/accounts/me/');
-            selectedBoardSkinClass = currentUser?.stats?.selected_board_skin_class || 'skin-board-classic';
-            selectedPieceSkinClass = currentUser?.stats?.selected_piece_skin_class || 'skin-piece-classic';
-            if (currentUser?.is_muted) {
-                setChatMutedState(true, currentUser.mute_reason || '');
-            }
-            if (currentUser?.is_suspended) {
-                setSuspendedState(true, currentUser.suspension_reason || '');
-            }
-            setupNotificationEvents();
-        } catch {
-            // 관전자로 처리
-            currentUser = null;
-        }
-
         setupBoard();
+        currentUserReadyPromise = hydrateCurrentUser();
         await loadGame();
         setupChat();
         setupMobileTabs();
@@ -252,6 +238,24 @@
         if (!replayOnly) {
             connectWebSocket();
         }
+    }
+
+    async function hydrateCurrentUser() {
+        try {
+            currentUser = await API.get('/accounts/me/');
+            selectedBoardSkinClass = currentUser?.stats?.selected_board_skin_class || 'skin-board-classic';
+            selectedPieceSkinClass = currentUser?.stats?.selected_piece_skin_class || 'skin-piece-classic';
+            if (currentUser?.is_muted) {
+                setChatMutedState(true, currentUser.mute_reason || '');
+            }
+            if (currentUser?.is_suspended) {
+                setSuspendedState(true, currentUser.suspension_reason || '');
+            }
+            setupNotificationEvents();
+        } catch {
+            currentUser = null;
+        }
+        return currentUser;
     }
 
     function mountReplayDock() {
@@ -429,6 +433,8 @@
                 }
             }
 
+            await currentUserReadyPromise;
+
             syncPerspectiveFromGame();
 
             if (!myColor || replayOnly) {
@@ -470,26 +476,48 @@
             renderMoveList();
             updateTurn();
             startTimer();
-            const initialTasks = [
-                loadCapturedPieces(),
-                refreshSpectatorList(),
-            ];
-            if (game.move_count > 0) {
-                initialTasks.push(loadLastMove());
-            }
-            await Promise.allSettled(initialTasks);
-            renderCapturedPieces();
-            if (game.move_count > 0) {
-                renderBoard({ animatePieceChanges: false });
-                updateTurn();
-                scheduleMoveCacheWarmup();
-            }
+            schedulePostLoadHydration();
             if (replayOnly && replayGameParamId) {
                 await openReplay(replayGameParamId);
             }
         } catch (error) {
             console.error('Failed to load game:', error);
             Toast.error('게임 정보를 불러올 수 없습니다.');
+        }
+    }
+
+    function scheduleDeferredTask(task, { timeout = 300 } = {}) {
+        const run = () => Promise.resolve().then(task).catch(() => {});
+        requestAnimationFrame(() => {
+            if (typeof window.requestIdleCallback === 'function') {
+                window.requestIdleCallback(run, { timeout });
+            } else {
+                setTimeout(run, 0);
+            }
+        });
+    }
+
+    function schedulePostLoadHydration() {
+        if (!game) return;
+
+        if (game.move_count > 0) {
+            scheduleDeferredTask(async () => {
+                await loadCapturedPieces();
+                renderCapturedPieces();
+            }, { timeout: 350 });
+
+            scheduleDeferredTask(async () => {
+                await loadLastMove();
+                renderBoard({ animatePieceChanges: false });
+                updateTurn();
+                scheduleMoveCacheWarmup();
+            }, { timeout: 500 });
+        } else {
+            renderCapturedPieces();
+        }
+
+        if (!isAiRoom) {
+            scheduleDeferredTask(() => refreshSpectatorList(), { timeout: 900 });
         }
     }
 
@@ -558,7 +586,6 @@
         replayActive = false;
         captured = { white: [], black: [] };
         hasShownStartGuide = false;
-        lastTurnColor = null;
         wsReconnectAttempts = 0;
 
         let fetched = null;
@@ -597,12 +624,7 @@
         renderMoveList();
         updateTurn();
         startTimer();
-        Promise.allSettled([
-            loadCapturedPieces(),
-            refreshSpectatorList(),
-        ]).then(() => {
-            renderCapturedPieces();
-        });
+        schedulePostLoadHydration();
         connectWebSocket();
     }
 
@@ -1022,105 +1044,12 @@
      * 플레이어 바 렌더링
      */
     function renderPlayerBars() {
-        if (!game) return;
-
-        const whitePlayer = game.white_player;
-        const blackPlayer = game.black_player;
-
-        // 내가 흑이면 보드를 뒤집어야 함 (상대가 위에)
-        const isFlipped = myColor === 'black';
-        const topPlayer = isFlipped ? whitePlayer : blackPlayer;
-        const bottomPlayer = isFlipped ? blackPlayer : whitePlayer;
-
-        // 상대 (위)
-        const topTier = topPlayer?.rank_tier || 'Junior';
-        const bottomTier = bottomPlayer?.rank_tier || 'Junior';
-        const topNicknameColor = Utils.getNicknameColorValue(topPlayer?.nickname_color || '');
-        const bottomNicknameColor = Utils.getNicknameColorValue(bottomPlayer?.nickname_color || '');
-        const topProfileRing = Utils.getProfileBorderValue(topPlayer?.profile_border || '');
-        const bottomProfileRing = Utils.getProfileBorderValue(bottomPlayer?.profile_border || '');
-        renderPlayerBar({
-            container: opponentBar,
-            player: topPlayer,
-            fallbackName: '상대',
-            nicknameColor: topNicknameColor,
-            profileRing: topProfileRing,
-            tier: topTier,
-            timerId: 'opponent-timer',
+        statusUI?.renderPlayerBars({
+            game,
+            myColor,
+            opponentBar,
+            myBar,
         });
-
-        renderPlayerBar({
-            container: myBar,
-            player: bottomPlayer,
-            fallbackName: '나',
-            nicknameColor: bottomNicknameColor,
-            profileRing: bottomProfileRing,
-            tier: bottomTier,
-            timerId: 'my-timer',
-        });
-    }
-
-    function renderPlayerBar({
-        container,
-        player,
-        fallbackName,
-        nicknameColor,
-        profileRing,
-        tier,
-        timerId,
-    }) {
-        if (!container) return;
-        container.textContent = '';
-
-        const info = document.createElement('div');
-        info.className = 'player-bar-info';
-
-        const avatar = document.createElement('div');
-        avatar.className = 'avatar avatar-sm';
-        if (profileRing) avatar.style.boxShadow = profileRing;
-        Utils.setAvatar(avatar, {
-            url: player?.avatar_url,
-            alt: player?.nickname || fallbackName,
-            placeholder: '?',
-            placeholderClass: 'avatar-placeholder',
-        });
-        info.appendChild(avatar);
-
-        const details = document.createElement('div');
-        details.className = 'player-bar-details';
-
-        const name = document.createElement('span');
-        name.className = 'player-bar-name';
-        if (nicknameColor) name.style.color = nicknameColor;
-        name.appendChild(document.createTextNode(player?.nickname || fallbackName));
-        name.appendChild(document.createTextNode(' '));
-        const badge = document.createElement('span');
-        badge.className = 'tier-badge';
-        badge.title = tier || '';
-        badge.textContent = Utils.getTierIcon(tier || '');
-        name.appendChild(badge);
-        details.appendChild(name);
-
-        const rating = document.createElement('span');
-        rating.className = 'player-bar-rating';
-        rating.textContent = String(player?.rating || '--');
-        details.appendChild(rating);
-
-        if (player?.featured_achievement?.title) {
-            const achievement = document.createElement('span');
-            achievement.className = `player-bar-achievement player-bar-achievement--${player.featured_achievement.tone || 'info'}`;
-            achievement.textContent = `${player.featured_achievement.icon || '🏅'} ${player.featured_achievement.title}`;
-            details.appendChild(achievement);
-        }
-
-        info.appendChild(details);
-        container.appendChild(info);
-
-        const timer = document.createElement('div');
-        timer.className = 'player-bar-timer';
-        timer.id = timerId;
-        timer.textContent = '--:--';
-        container.appendChild(timer);
     }
 
     /**
@@ -1204,16 +1133,6 @@
         });
     }
 
-    function setUiStateBadge(element, tone, text) {
-        if (!element) return;
-        const nextClass = ['ui-state-badge'];
-        if (tone === 'success') nextClass.push('ui-state-badge--success');
-        if (tone === 'pending') nextClass.push('ui-state-badge--pending');
-        if (tone === 'warning') nextClass.push('ui-state-badge--warning');
-        element.className = nextClass.join(' ');
-        element.textContent = text;
-    }
-
     function updateBoardBrandState() {
         if (!chessBoard || !game) return;
         chessBoard.classList.remove('is-check', 'is-checkmate');
@@ -1228,54 +1147,19 @@
         }
     }
 
-    function getModeBadgeText() {
-        if (replayOnly) return '기보 다시보기';
-        if (!game) return '실시간 대국';
-        if (isAiRoom) return 'AI 대전';
-        if (!myColor) return '관전 중';
-        if (game.room_type === 'competitive') return '경쟁전';
-        if (game.room_type === 'quick') return '빠른 대전';
-        return '실시간 대국';
-    }
-
     function updateGameStatusStrip() {
-        if (!game) return;
-
-        const modeTone = replayOnly ? 'warning' : (!myColor ? 'pending' : 'success');
-        setUiStateBadge(gameModeBadge, modeTone, getModeBadgeText());
-
-        if (game.result && game.result !== 'playing') {
-            const outcome = getOutcome(game.result, myColor);
-            if (outcome === 'win') {
-                setUiStateBadge(gameTurnBadge, 'success', '결과: 승리');
-            } else if (outcome === 'loss') {
-                setUiStateBadge(gameTurnBadge, 'warning', '결과: 패배');
-            } else if (outcome === 'draw') {
-                setUiStateBadge(gameTurnBadge, 'pending', '결과: 무승부');
-            } else {
-                setUiStateBadge(gameTurnBadge, '', '결과 확정');
-            }
-        } else if (!myColor) {
-            setUiStateBadge(gameTurnBadge, 'pending', game.current_turn === 'white' ? '백 차례' : '흑 차례');
-        } else {
-            setUiStateBadge(gameTurnBadge, isMyTurn ? 'success' : '', isMyTurn ? '내 차례' : '상대 차례');
-        }
-
-        if (lastMove?.is_checkmate) {
-            setUiStateBadge(gameAlertBadge, 'warning', '체크메이트');
-        } else if (lastMove?.is_check && game.result === 'playing') {
-            setUiStateBadge(
-                gameAlertBadge,
-                'warning',
-                !myColor ? '체크 발생' : (game.current_turn === myColor ? '체크 경고' : '상대 킹 체크')
-            );
-        } else if (replayOnly) {
-            setUiStateBadge(gameAlertBadge, '', '기보를 단계별로 다시볼 수 있습니다');
-        } else if (!myColor) {
-            setUiStateBadge(gameAlertBadge, '', '우측 패널에서 기보·관전자·채팅 확인');
-        } else {
-            setUiStateBadge(gameAlertBadge, '', '우측 패널에서 기보·채팅·액션 확인');
-        }
+        statusUI?.updateStatusStrip({
+            game,
+            replayOnly,
+            isAiRoom,
+            myColor,
+            isMyTurn,
+            lastMove,
+            gameModeBadge,
+            gameTurnBadge,
+            gameAlertBadge,
+            getOutcome,
+        });
     }
 
     /**
@@ -1285,39 +1169,18 @@
         if (!game) return;
 
         isMyTurn = myColor === game.current_turn;
-
-        const isFlipped = myColor === 'black';
-        const isWhiteTurn = game.current_turn === 'white';
-        const isTopPlayerTurn = isFlipped ? isWhiteTurn : !isWhiteTurn;
-
-        opponentBar.classList.toggle('active', isTopPlayerTurn);
-        myBar.classList.toggle('active', !isTopPlayerTurn);
-
-        // 관전자면 액션 버튼 숨기기
-        if (!myColor) {
-            gameActions.style.display = 'none';
-        }
-
-        const whiteName = game.white_player?.nickname || '화이트';
-        const blackName = game.black_player?.nickname || '블랙';
-        const currentName = game.current_turn === 'white' ? whiteName : blackName;
-
-        if (turnIndicator) {
-            if (!hasShownStartGuide && game.move_count === 0) {
-                turnIndicator.textContent = `${currentName}님부터 시작합니다. 번갈아가며 한 번씩 수를 둡니다.`;
-            } else {
-                turnIndicator.textContent = `지금은 ${currentName}님의 차례입니다.`;
-            }
-        }
-
-        if (!hasShownStartGuide && game.move_count === 0) {
-            showStatusModal(`${currentName}님부터 시작합니다. 번갈아가며 한 번씩 수를 둡니다.`, 2500);
-            hasShownStartGuide = true;
-        }
-
-        if (!lastTurnColor) {
-            lastTurnColor = game.current_turn;
-        }
+        const turnState = statusUI?.updateTurnPresentation({
+            game,
+            myColor,
+            isMyTurn,
+            opponentBar,
+            myBar,
+            gameActions,
+            turnIndicator,
+            hasShownStartGuide,
+            showStatusModal,
+        });
+        hasShownStartGuide = turnState?.hasShownStartGuide ?? hasShownStartGuide;
 
         updateGameStatusStrip();
     }
@@ -1350,7 +1213,7 @@
     function checkTimeout() {
         if (timeoutHandled || !game || game.result !== 'playing') return;
 
-        const liveTimes = getLiveTimeSnapshot();
+        const liveTimes = statusUI?.getLiveTimeSnapshot({ game }) || { white: 0, black: 0 };
         const myTime = myColor === 'white' ? liveTimes.white : liveTimes.black;
         const opponentTime = myColor === 'white' ? liveTimes.black : liveTimes.white;
 
@@ -1374,44 +1237,12 @@
      * 타이머 표시 업데이트
      */
     function updateTimerDisplay() {
-        if (!game) return;
-
-        const isFlipped = myColor === 'black';
-        const liveTimes = getLiveTimeSnapshot();
-        const topTime = isFlipped ? liveTimes.white : liveTimes.black;
-        const bottomTime = isFlipped ? liveTimes.black : liveTimes.white;
-
-        const opponentTimerEl = opponentBar.querySelector('.player-bar-timer');
-        const myTimerEl = myBar.querySelector('.player-bar-timer');
-
-        if (opponentTimerEl) {
-            opponentTimerEl.textContent = Utils.formatTime(topTime);
-            opponentTimerEl.classList.toggle('low', topTime < 30);
-        }
-        if (myTimerEl) {
-            myTimerEl.textContent = Utils.formatTime(bottomTime);
-            myTimerEl.classList.toggle('low', bottomTime < 30);
-        }
-    }
-
-    function getLiveTimeSnapshot() {
-        if (!game) {
-            return { white: 0, black: 0 };
-        }
-        let white = Number(game.white_time_remaining || 0);
-        let black = Number(game.black_time_remaining || 0);
-        if (game.result === 'playing' && game.turn_started_at) {
-            const startedAt = new Date(game.turn_started_at).getTime();
-            if (!Number.isNaN(startedAt)) {
-                const elapsed = Math.max(0, (Date.now() - startedAt) / 1000);
-                if (game.current_turn === 'white') {
-                    white = Math.max(0, white - elapsed);
-                } else {
-                    black = Math.max(0, black - elapsed);
-                }
-            }
-        }
-        return { white, black };
+        statusUI?.updateTimerDisplay({
+            game,
+            myColor,
+            opponentBar,
+            myBar,
+        });
     }
 
     /**

--- a/templates/chess/game.html
+++ b/templates/chess/game.html
@@ -371,6 +371,8 @@
 .main-content:has(.game-container) {
     padding-top: calc(var(--navbar-height) + var(--space-sm));
     padding-bottom: var(--space-sm);
+    width: min(100%, 1760px);
+    max-width: none;
 }
 
 @media (max-width: 768px) {
@@ -378,6 +380,7 @@
         padding: var(--space-xs);
         padding-top: calc(var(--navbar-height) + var(--space-xs));
         padding-bottom: 70px;
+        width: 100%;
     }
 }
 
@@ -1983,12 +1986,12 @@ html[data-theme="dark"] .piece.white {
 
 @media (max-width: 1500px) {
     .game-container {
-        grid-template-columns: minmax(560px, 680px) minmax(360px, 1fr);
-        max-width: 1440px;
+        grid-template-columns: minmax(600px, 700px) minmax(400px, 1fr);
+        max-width: 1560px;
     }
 
     .panel-top-grid {
-        grid-template-columns: minmax(200px, 228px) minmax(0, 1fr);
+        grid-template-columns: minmax(220px, 250px) minmax(0, 1fr);
     }
 }
 
@@ -2997,6 +3000,7 @@ body.competitive-room #rematch-modal {
 {% block extra_js %}
 <script src="{% static 'js/components/game_board_ui.js' %}"></script>
 <script src="{% static 'js/components/game_socket_client.js' %}"></script>
+<script src="{% static 'js/components/game_status_ui.js' %}"></script>
 <script src="{% static 'js/components/game_moves_cache.js' %}"></script>
 <script src="{% static 'js/components/game_analysis_ui.js' %}"></script>
 <script src="{% static 'js/components/game_side_panels_ui.js' %}"></script>


### PR DESCRIPTION
## 📝 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
  - 길드와 파티는 둘러보기 / 생성 / 내 관리 흐름으로 분리되어, 탐색 화면과 운영 화면이 목적에 맞게 나뉘었습니다.
  - 길드 공지는 이력형으로 바뀌어 이전 공지를 계속 볼 수 있고, 저장 직후 이력과 요약에 바로 반영되며 길드원 알림도 함께 전송됩니다.
  - 길드 관리 화면은 브랜딩, 공지, 멤버 관리, 채팅, 가입 요청 중심으로 정리되어 불필요한 운영 정보 없이 핵심 기능만 남았습니다.
  - 길드 모바일 진입 시 뜨던 guildNoticeInput null 오류는 DOM 가드와 캐시 무효화로 정리되어, iPhone Safari까지 포함해 초기 진입 안정성이 올라갔습니다.
  - 길드 목록 카드는 아바타와 텍스트 정렬을 다시 맞춰, 데스크톱에서도 미세하게 눌리거나 잘려 보이던 문제가 줄었습니다.
  - 커스터마이징은 탭형 구조와 쇼룸 재배치로 긴 스크롤 부담이 줄었고, 모바일에서도 미리보기를 더 빨리 확인할 수 있게 됐습니다.
  - 쇼룸은 프로필 카드와 보드 미리보기 비율을 다시 잡아, 모바일에서 옆으로 밀리거나 잘리는 현상이 완화됐습니다.
  - 전역 채팅은 로비 / 1:1 / 길드 / 파티 탭 구조로 확장되어 여러 채널을 한 패널 안에서 빠르게 오갈 수 있게 됐습니다.
  - 길드·파티 채팅에도 뒤로가기와 토글 흐름이 추가되어, 1:1 채팅처럼 자연스럽게 복귀할 수 있게 됐습니다.
  - 게임 화면은 보드 크기를 복구하고 우측 패널이 실제 우측 공간을 더 쓰도록 다시 정리되어, 가운데에 낑겨 보이던 느낌이 줄었습니다.
  - 대전 메뉴는 세로로 눌려 읽기 어렵던 상태에서 벗어나 가로 비율과 설명 텍스트가 더 읽기 좋게 정리됐습니다.
  - 모바일에서 화면이 꺼졌다가 돌아왔을 때도 최신 게임 상태를 다시 동기화하도록 보강돼, 상대 기권·종료 상태가 늦게 반영되던 문제가 줄었습니다.
  - 게임 스크립트는 분석, 종료 요약, 상태 UI, 보드/소켓 헬퍼 분리와 초기 로드 지연 처리로 첫 진입 렉과 유지보수 부담을 함께 낮추는 방향으로 정리됐습니다.
  - 방 목록, 게시판 댓글, 전역 채팅, 운영 화면은 전체 재렌더와 불필요한 폴링 비중이 줄어들어 브라우저 비용과 서버 요청이 더 안정적으로 관리되는 구조로 바뀌었습니
  다.

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 (예: Closes #123) -->


## 📋 변경 타입
<!-- 해당하는 항목에 [x] 표시해주세요 -->

- [ ] 새로운 기능 (New Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation)
- [ ] 스타일 변경 (Style)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포 (Build/Deploy)
- [ ] 기타 (Other)

## ✅ 체크리스트
<!-- PR 제출 전에 확인해주세요 -->

- [ ] 로컬에서 테스트 완료
- [ ] 코드 포맷팅 적용 (`./scripts/format.sh`)
- [ ] 테스트 통과 (`./scripts/test.sh`)
- [ ] 마이그레이션 파일 포함 (필요한 경우)
- [ ] 문서 업데이트 (필요한 경우)

## 📸 스크린샷 (선택사항)
<!-- UI 변경이 있다면 스크린샷을 추가해주세요 -->


## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

