### PR TITLE
[Refactor/minsoo] 게임환경에서 대전메뉴 세로길이 증축

### DIFF
--- a/templates/chess/game.html
+++ b/templates/chess/game.html
@@ -61,7 +61,7 @@
                         <h3 class="panel-title">대전 메뉴</h3>
                         <p class="panel-copy">대국 관련 액션은 여기서 처리합니다.</p>
                     </div>
-                    <div style="display: flex; gap: 8px; align-items: center;">
+                    <div class="game-actions-toolbar">
                         <label class="guide-toggle" title="착수 전 확인 버튼을 띄웁니다.">
                             <input type="checkbox" id="move-confirm-toggle" style="width: 14px; height: 14px; cursor: pointer;">
                             <span style="font-size: 11px;">수 확인</span>
@@ -1775,19 +1775,30 @@ html[data-theme="dark"] .piece.white {
 
 .game-actions-panel .panel-header {
     border-bottom: 0;
-    padding-bottom: var(--space-sm);
+    padding-bottom: var(--space-md);
     text-align: left;
-    align-items: flex-start;
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0.8rem;
 }
 
 .game-actions-panel {
     min-width: 0;
+    min-height: 272px;
+}
+
+.game-actions-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+    flex-wrap: wrap;
 }
 
 .game-actions-panel .action-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: var(--space-sm);
+    gap: 0.7rem;
     padding: 0 var(--space-md) var(--space-md);
 }
 
@@ -1795,6 +1806,7 @@ html[data-theme="dark"] .piece.white {
     min-width: 0;
     width: 100%;
     justify-content: center;
+    min-height: 44px;
 }
 
 .panel-title {


### PR DESCRIPTION
## 📝 변경 사항
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
  - 기존 대전메뉴는 세로축이 고정이되어있어서 대전메뉴 ui가 보기 불편한점 개선

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 (예: Closes #123) -->


## 📋 변경 타입
<!-- 해당하는 항목에 [x] 표시해주세요 -->

- [ ] 새로운 기능 (New Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 업데이트 (Documentation)
- [ ] 스타일 변경 (Style)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포 (Build/Deploy)
- [ ] 기타 (Other)

## ✅ 체크리스트
<!-- PR 제출 전에 확인해주세요 -->

- [ ] 로컬에서 테스트 완료
- [ ] 코드 포맷팅 적용 (`./scripts/format.sh`)
- [ ] 테스트 통과 (`./scripts/test.sh`)
- [ ] 마이그레이션 파일 포함 (필요한 경우)
- [ ] 문서 업데이트 (필요한 경우)

## 📸 스크린샷 (선택사항)
<!-- UI 변경이 있다면 스크린샷을 추가해주세요 -->


## 💡 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

